### PR TITLE
feat: add support in document declaration to pass headers to the request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ First of all, thanks for taking the time to contribute! 🎉👍
       - [Range selectors](#range-selectors)
     - [`remove`](#remove)
     - [`filter`](#filter)
+    - [`headers`](#headers)
     - [Document type](#document-type)
       - [Defining a new document type](#defining-a-new-document-type)
   - [Testing your declaration](#testing-your-declaration)
@@ -103,6 +104,7 @@ Documents are declared in a service declaration file, under the `documents` prop
       "filter": "An array of service specific filter function names",
       "remove": "A CSS selector, a range selector or an array of selectors that target the noise parts of the document that has to be removed. Useful to remove parts that are inside the selected parts",
       "select": "A CSS selector, a range selector or an array of selectors that target the meaningful parts of the document, excluding elements such as headers, footers and navigation",
+      "headers": "An object representing headers to be passed to the url fetcher",
     }
   }
   …
@@ -221,6 +223,17 @@ export function removeImages(document, { select: selector }) {
 You can find examples of filters in [`/services/*.filters.js`](./services) files.
 
 You can also learn more about [usual noise](https://github.com/ambanum/OpenTermsArchive/wiki/Usual-noise) and ways to handle it on the wiki, and share your own learnings there.
+
+### `headers`
+
+_This property is optional._
+
+It can happen that retrieving a document through scraping needs some additional headers to work correctly.
+
+Some of theme could be
+
+- **user-agent**: to force a specific user agent
+- **Cookie**: to pass meaningful data such as a language to fetch the data in (i.e. for Instagram: `"headers": { "Cookie": "locale=en_GB" }`)
 
 ### Document type
 

--- a/scripts/validation/service.schema.js
+++ b/scripts/validation/service.schema.js
@@ -103,6 +103,15 @@ const schema = {
           description:
             'Execute client-side JavaScript loaded by the document before accessing the content, in case the DOM modifications are needed to access the content.',
         },
+        headers: {
+          type: 'object',
+          properties: {
+            'user-agent': { type: 'string' },
+            Cookie: { type: 'string' },
+          },
+          additionalProperties: true,
+          description: 'Headers object as supported by node-fetch',
+        },
       },
     },
     cssSelector: {

--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -81,11 +81,14 @@ let servicesToValidate = args.filter((arg) => !arg.startsWith('--'));
               it('has fetchable URL', async function () {
                 this.timeout(30000);
 
-                const { location, executeClientScripts } = service.getDocumentDeclaration(type);
+                const { location, executeClientScripts, headers } = service.getDocumentDeclaration(
+                  type
+                );
                 const document = await fetch({
                   url: location,
                   executeClientScripts,
                   cssSelectors: service.getDocumentDeclaration(type).getCssSelectors(),
+                  headers,
                 });
                 content = document.content;
                 mimeType = document.mimeType;
@@ -135,11 +138,16 @@ let servicesToValidate = args.filter((arg) => !arg.startsWith('--'));
 
                   this.timeout(30000);
 
-                  const { location, executeClientScripts } = service.getDocumentDeclaration(type);
+                  const {
+                    location,
+                    executeClientScripts,
+                    headers,
+                  } = service.getDocumentDeclaration(type);
                   const document = await fetch({
                     url: location,
                     executeClientScripts,
                     cssSelectors: service.getDocumentDeclaration(type).getCssSelectors(),
+                    headers,
                   });
 
                   const secondFilteredContent = await filter({

--- a/src/app/fetcher/fullDomFetcher.js
+++ b/src/app/fetcher/fullDomFetcher.js
@@ -9,7 +9,7 @@ const PUPPETEER_TIMEOUT = 60 * 1000; // 60s
 
 let browser;
 
-export default async function fetch(url, cssSelectors) {
+export default async function fetch(url, cssSelectors, headers = {}) {
   let response;
   let content;
   let page;
@@ -26,6 +26,10 @@ export default async function fetch(url, cssSelectors) {
     await page.setDefaultNavigationTimeout(PUPPETEER_TIMEOUT);
 
     response = await page.goto(url, { waitUntil: 'networkidle0' });
+    await page.setExtraHTTPHeaders({
+      ...headers,
+    });
+
     const statusCode = response.status();
 
     if (statusCode < 200 || statusCode >= 300) {

--- a/src/app/fetcher/htmlOnlyFetcher.js
+++ b/src/app/fetcher/htmlOnlyFetcher.js
@@ -5,7 +5,7 @@ import https from 'https';
 import nodeFetch from 'node-fetch';
 const LANGUAGE = 'en';
 
-export default async function fetch(url) {
+export default async function fetch(url, { headers = {} } = {}) {
   const options = {};
 
   if (url.startsWith('https:') && process.env.HTTPS_PROXY) {
@@ -18,7 +18,9 @@ export default async function fetch(url) {
       rejectUnauthorized: false,
     });
   }
-  options.headers = { 'Accept-Language': LANGUAGE };
+
+  options.credentials = 'include';
+  options.headers = { 'Accept-Language': LANGUAGE, ...headers };
 
   let response;
 

--- a/src/app/fetcher/index.js
+++ b/src/app/fetcher/index.js
@@ -1,10 +1,10 @@
 import fetchFullDom from './fullDomFetcher.js';
 import fetchHtmlOnly from './htmlOnlyFetcher.js';
 
-export default async function fetch({ url, executeClientScripts, cssSelectors }) {
+export default async function fetch({ url, executeClientScripts, cssSelectors, headers }) {
   if (executeClientScripts) {
-    return fetchFullDom(url, cssSelectors);
+    return fetchFullDom(url, cssSelectors, headers);
   }
 
-  return fetchHtmlOnly(url);
+  return fetchHtmlOnly(url, { headers });
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -157,6 +157,7 @@ export default class CGUs extends events.EventEmitter {
     const {
       location,
       executeClientScripts,
+      headers,
       service,
       contentSelectors,
       noiseSelectors,
@@ -167,6 +168,7 @@ export default class CGUs extends events.EventEmitter {
       url: location,
       executeClientScripts,
       cssSelectors: documentDeclaration.getCssSelectors(),
+      headers,
     });
 
     await github.closeIssueIfExists({

--- a/src/app/services/documentDeclaration.js
+++ b/src/app/services/documentDeclaration.js
@@ -5,6 +5,7 @@ export default class DocumentDeclaration {
     location,
     executeClientScripts,
     contentSelectors,
+    headers,
     noiseSelectors,
     filters,
     validUntil = null,
@@ -15,6 +16,7 @@ export default class DocumentDeclaration {
     this.executeClientScripts = executeClientScripts;
     this.contentSelectors = contentSelectors;
     this.noiseSelectors = noiseSelectors;
+    this.headers = headers;
     this.filters = filters;
     this.validUntil = validUntil;
   }

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -1,11 +1,11 @@
 import { fileURLToPath, pathToFileURL } from 'url';
 
+import DocumentDeclaration from './documentDeclaration.js';
+import Service from './service.js';
 import config from 'config';
 import fsApi from 'fs';
 import path from 'path';
 import simpleGit from 'simple-git';
-import Service from './service.js';
-import DocumentDeclaration from './documentDeclaration.js';
 
 const fs = fsApi.promises;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -42,6 +42,7 @@ export async function load() {
           const {
             filter: filterNames,
             fetch: location,
+            headers,
             executeClientScripts,
             select: contentSelectors,
             remove: noiseSelectors,
@@ -63,6 +64,7 @@ export async function load() {
             contentSelectors,
             noiseSelectors,
             filters,
+            headers,
           });
 
           services[service.id].addDocumentDeclaration(document);


### PR DESCRIPTION
In order to make Instagram not fetched in french, we need to add a proper `locale` cookie that is not `en` but `en_GB`.
Passing `en_IE` would not work either so this can not not be handled in a global manner.

So we're adding a new field that can be customized in a service that is called `headers`.
This gives another level of autonomy to a user that could contribute.



