### PR TITLE
Whitelist `ERR_TOO_MANY_REDIRECTS` fetch error

### DIFF
--- a/src/app/fetcher/errors.js
+++ b/src/app/fetcher/errors.js
@@ -8,6 +8,7 @@ export const ErrorCodes = [
   'ERR_NAME_NOT_RESOLVED', // Network Error
   'ERR_TUNNEL_CONNECTION_FAILED', // Network Error
   'ETIMEDOUT', // Network Error
+  'ERR_TOO_MANY_REDIRECTS', // Network Error
   'CERT_HAS_EXPIRED', // Certificate Error
   'DEPTH_ZERO_SELF_SIGNED_CERT', // Certificate Error
   'ERR_CERT_AUTHORITY_INVALID', // Certificate Error

--- a/src/app/fetcher/errors.js
+++ b/src/app/fetcher/errors.js
@@ -8,7 +8,7 @@ export const ErrorCodes = [
   'ERR_NAME_NOT_RESOLVED', // Network Error
   'ERR_TUNNEL_CONNECTION_FAILED', // Network Error
   'ETIMEDOUT', // Network Error
-  'ERR_TOO_MANY_REDIRECTS', // Network Error
+  'ERR_TOO_MANY_REDIRECTS', // Server Error
   'CERT_HAS_EXPIRED', // Certificate Error
   'DEPTH_ZERO_SELF_SIGNED_CERT', // Certificate Error
   'ERR_CERT_AUTHORITY_INVALID', // Certificate Error


### PR DESCRIPTION
Consider content inaccessible on `ERR_TOO_MANY_REDIRECTS` errors