### PR TITLE
Improve Eslint configuration

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -21,7 +21,9 @@ rules:
       singleValue: false
   eqeqeq: 0
   chai-friendly/no-unused-expressions: 2
-  comma-dangle: 0
+  comma-dangle:
+    - error
+    - always-multiline
   consistent-return: 0
   function-paren-newline:
     - error

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -46,6 +46,9 @@ rules:
     - error
     - 2
   max-len: 0
+  object-curly-newline:
+    - error
+    - multiline: true
   no-console: 0
   no-param-reassign: 0
   no-plusplus: 0
@@ -58,7 +61,6 @@ rules:
     - error
     - argsIgnorePattern: next
   no-use-before-define: 0
-  object-curly-newline: 0
   padding-line-between-statements:
     - error
     - blankLine: always

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -79,3 +79,10 @@ rules:
         - const
         - let
         - var
+
+overrides:
+- files:
+  - src/**/*test.js
+  - scripts/validation/*.js
+  rules:
+    func-names: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -86,3 +86,9 @@ overrides:
   - scripts/validation/*.js
   rules:
     func-names: 0
+- files:
+  - scripts/**/*.js
+  rules:
+    func-names: 0
+    import/no-extraneous-dependencies: 0
+

--- a/scripts/export/makedataset.js
+++ b/scripts/export/makedataset.js
@@ -139,7 +139,7 @@ async function main() {
   const finalPath = path.resolve(
     __dirname,
     '../../data/',
-    `${exportTargetFolderName}-${date}-${headCommitShortSha}`
+    `${exportTargetFolderName}-${date}-${headCommitShortSha}`,
   );
 
   console.log(`Exporting dataset to ${finalPath}`);

--- a/scripts/rewrite/rewrite-versions.js
+++ b/scripts/rewrite/rewrite-versions.js
@@ -18,7 +18,7 @@ const ROOT_PATH = path.resolve(__dirname, '../../');
 
 export const SNAPSHOTS_SOURCE_PATH = path.resolve(
   ROOT_PATH,
-  config.get('rewrite.snapshotsSourcePath')
+  config.get('rewrite.snapshotsSourcePath'),
 );
 export const VERSIONS_TARGET_PATH = path.resolve(ROOT_PATH, config.get('history.versionsPath'));
 
@@ -82,7 +82,7 @@ let history;
 
     const documentDeclaration = servicesDeclarations[serviceId].getDocumentDeclaration(
       documentType,
-      commit.date
+      commit.date,
     );
 
     if (!documentDeclaration) {

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import fsApi from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -43,11 +43,11 @@ const DOWNLOAD_HISTORY_MESSAGE = `Download the entire history of terms of servic
 
       await git.clone(
         config.get('history.publicVersionsRepository'),
-        config.get('history.versionsPath')
+        config.get('history.versionsPath'),
       );
       await git.clone(
         config.get('history.publicSnapshotsRepository'),
-        config.get('history.snapshotsPath')
+        config.get('history.snapshotsPath'),
       );
     }
 

--- a/scripts/validation/service.history.schema.js
+++ b/scripts/validation/service.history.schema.js
@@ -28,7 +28,7 @@ const schema = {
   additionalProperties: false,
   title: 'Service declaration history',
   properties: documentsProperties(),
-  propertyNames: { enum: AVAILABLE_TYPES_NAME, },
+  propertyNames: { enum: AVAILABLE_TYPES_NAME },
   definitions: {
     pdfDocument: {
       type: 'object',
@@ -104,7 +104,7 @@ const schema = {
           type: 'boolean',
           description:
             'Execute client-side JavaScript loaded by the document before accessing the content, in case the DOM modifications are needed to access the content.',
-        }
+        },
       },
     },
     cssSelector: {

--- a/scripts/validation/service.history.schema.js
+++ b/scripts/validation/service.history.schema.js
@@ -28,9 +28,7 @@ const schema = {
   additionalProperties: false,
   title: 'Service declaration history',
   properties: documentsProperties(),
-  propertyNames: {
-    enum: AVAILABLE_TYPES_NAME,
-  },
+  propertyNames: { enum: AVAILABLE_TYPES_NAME, },
   definitions: {
     pdfDocument: {
       type: 'object',

--- a/scripts/validation/service.schema.js
+++ b/scripts/validation/service.schema.js
@@ -9,7 +9,7 @@ const documentsProperties = () => {
   const result = {};
 
   AVAILABLE_TYPES_NAME.forEach(type => {
-    result[type] = { oneOf: [{ $ref: '#/definitions/document' }, { $ref: '#/definitions/pdfDocument' }], };
+    result[type] = { oneOf: [{ $ref: '#/definitions/document' }, { $ref: '#/definitions/pdfDocument' }] };
   });
 
   return result;
@@ -29,7 +29,7 @@ const schema = {
     documents: {
       type: 'object',
       properties: documentsProperties(),
-      propertyNames: { enum: AVAILABLE_TYPES_NAME, },
+      propertyNames: { enum: AVAILABLE_TYPES_NAME },
     },
     importedFrom: {
       type: 'string',
@@ -69,7 +69,7 @@ const schema = {
             { $ref: '#/definitions/range' },
             {
               type: 'array',
-              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }], },
+              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }] },
             },
           ],
         },
@@ -88,7 +88,7 @@ const schema = {
             { $ref: '#/definitions/range' },
             {
               type: 'array',
-              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }], },
+              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }] },
             },
           ],
         },
@@ -96,7 +96,7 @@ const schema = {
           type: 'boolean',
           description:
             'Execute client-side JavaScript loaded by the document before accessing the content, in case the DOM modifications are needed to access the content.',
-        }
+        },
       },
     },
     cssSelector: {

--- a/scripts/validation/service.schema.js
+++ b/scripts/validation/service.schema.js
@@ -9,9 +9,7 @@ const documentsProperties = () => {
   const result = {};
 
   AVAILABLE_TYPES_NAME.forEach(type => {
-    result[type] = {
-      oneOf: [{ $ref: '#/definitions/document' }, { $ref: '#/definitions/pdfDocument' }],
-    };
+    result[type] = { oneOf: [{ $ref: '#/definitions/document' }, { $ref: '#/definitions/pdfDocument' }], };
   });
 
   return result;
@@ -31,9 +29,7 @@ const schema = {
     documents: {
       type: 'object',
       properties: documentsProperties(),
-      propertyNames: {
-        enum: AVAILABLE_TYPES_NAME,
-      },
+      propertyNames: { enum: AVAILABLE_TYPES_NAME, },
     },
     importedFrom: {
       type: 'string',
@@ -73,9 +69,7 @@ const schema = {
             { $ref: '#/definitions/range' },
             {
               type: 'array',
-              items: {
-                oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }],
-              },
+              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }], },
             },
           ],
         },
@@ -94,9 +88,7 @@ const schema = {
             { $ref: '#/definitions/range' },
             {
               type: 'array',
-              items: {
-                oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }],
-              },
+              items: { oneOf: [{ $ref: '#/definitions/cssSelector' }, { $ref: '#/definitions/range' }], },
             },
           ],
         },

--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import fsApi from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -66,7 +66,7 @@ let servicesToValidate = args.filter(arg => !arg.startsWith('--'));
             const declarationHistory = JSON.parse(await fs.readFile(path.join(
               rootPath,
               config.get('serviceDeclarationsPath'),
-              `${serviceId}.history.json`
+              `${serviceId}.history.json`,
             )));
 
             assertValid(serviceHistorySchema, declarationHistory);

--- a/src/app/fetcher/fullDomFetcher.js
+++ b/src/app/fetcher/fullDomFetcher.js
@@ -66,7 +66,7 @@ export async function launchHeadlessBrowser() {
 
   browser = await puppeteer.launch({
     headless: true,
-    args: [ '--no-sandbox', '--disable-setuid-sandbox' ]
+    args: [ '--no-sandbox', '--disable-setuid-sandbox' ],
   });
 }
 

--- a/src/app/fetcher/htmlOnlyFetcher.test.js
+++ b/src/app/fetcher/htmlOnlyFetcher.test.js
@@ -58,7 +58,7 @@ describe('HtmlOnlyFetcher', () => {
       it('throws a FetchDocumentError error', async () => {
         await expect(fetch('https://not.available.example')).to.be.rejectedWith(
           FetchDocumentError,
-          /404/
+          /404/,
         );
       });
     });

--- a/src/app/fetcher/index.test.js
+++ b/src/app/fetcher/index.test.js
@@ -52,7 +52,7 @@ describe('Fetcher', function () {
             await expect(fetch({
               url: `http://localhost:${SERVER_PORT}/404`,
               executeClientScripts: true,
-              cssSelectors: 'body'
+              cssSelectors: 'body',
             })).to.be.rejectedWith(FetchDocumentError, /404/);
           });
         });

--- a/src/app/filter/index.test.js
+++ b/src/app/filter/index.test.js
@@ -486,7 +486,7 @@ describe('Filter', () => {
       pdfContent = await fs.readFile(path.resolve(__dirname, '../../../test/fixtures/terms.pdf'));
       expectedFilteredContent = await fs.readFile(
         path.resolve(__dirname, '../../../test/fixtures/termsFromPDF.md'),
-        { encoding: 'utf8' }
+        { encoding: 'utf8' },
       );
     });
 

--- a/src/app/history/git.js
+++ b/src/app/history/git.js
@@ -24,9 +24,7 @@ export default class Git {
   }
 
   async commit(filepath, message, authorDate) {
-    const options = {
-      '--author': `${config.get('history.author').name} <${config.get('history.author').email}>`,
-    };
+    const options = { '--author': `${config.get('history.author').name} <${config.get('history.author').email}>`, };
 
     if (authorDate) {
       options['--date'] = new Date(authorDate).toISOString();

--- a/src/app/history/git.js
+++ b/src/app/history/git.js
@@ -24,7 +24,7 @@ export default class Git {
   }
 
   async commit(filepath, message, authorDate) {
-    const options = { '--author': `${config.get('history.author').name} <${config.get('history.author').email}>`, };
+    const options = { '--author': `${config.get('history.author').name} <${config.get('history.author').email}>` };
 
     if (authorDate) {
       options['--date'] = new Date(authorDate).toISOString();

--- a/src/app/history/index.js
+++ b/src/app/history/index.js
@@ -14,12 +14,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const SNAPSHOTS_PATH = path.resolve(
   __dirname,
   '../../..',
-  config.get('history.snapshotsPath')
+  config.get('history.snapshotsPath'),
 );
 export const VERSIONS_PATH = path.resolve(
   __dirname,
   '../../..',
-  config.get('history.versionsPath')
+  config.get('history.versionsPath'),
 );
 
 let snapshotRecorder;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -154,7 +154,7 @@ export default class CGUs extends events.EventEmitter {
 
     const { id: snapshotId, content: snapshotContent, mimeType } = await history.getLatestSnapshot(
       service.id,
-      type
+      type,
     );
 
     if (!snapshotId) {

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -41,16 +41,16 @@ describe('CGUs', function () {
   before(async () => {
     serviceASnapshotExpectedContent = await fs.readFile(
       path.resolve(__dirname, 'test/fixtures/service_A_terms_snapshot.html'),
-      { encoding: 'utf8' }
+      { encoding: 'utf8' },
     );
     serviceAVersionExpectedContent = await fs.readFile(
       path.resolve(__dirname, 'test/fixtures/service_A_terms.md'),
-      { encoding: 'utf8' }
+      { encoding: 'utf8' },
     );
     serviceBSnapshotExpectedContent = await fs.readFile(path.resolve(__dirname, 'test/fixtures/terms.pdf'));
     serviceBVersionExpectedContent = await fs.readFile(
       path.resolve(__dirname, 'test/fixtures/termsFromPDF.md'),
-      { encoding: 'utf8' }
+      { encoding: 'utf8' },
     );
   });
 
@@ -77,7 +77,7 @@ describe('CGUs', function () {
       it('records no snapshot for service A', async () => {
         const resultingSnapshotTerms = await fs.readFile(
           path.resolve(__dirname, SERVICE_A_EXPECTED_SNAPSHOT_FILE_PATH),
-          { encoding: 'utf8' }
+          { encoding: 'utf8' },
         );
 
         expect(resultingSnapshotTerms).to.equal(serviceASnapshotExpectedContent);
@@ -86,7 +86,7 @@ describe('CGUs', function () {
       it('records no version for service A', async () => {
         const resultingTerms = await fs.readFile(
           path.resolve(__dirname, SERVICE_A_EXPECTED_VERSION_FILE_PATH),
-          { encoding: 'utf8' }
+          { encoding: 'utf8' },
         );
 
         expect(resultingTerms).to.equal(serviceAVersionExpectedContent);
@@ -101,7 +101,7 @@ describe('CGUs', function () {
       it('records version for service B', async () => {
         const resultingTerms = await fs.readFile(
           path.resolve(__dirname, SERVICE_B_EXPECTED_VERSION_FILE_PATH),
-          { encoding: 'utf8' }
+          { encoding: 'utf8' },
         );
 
         expect(resultingTerms).to.equal(serviceBVersionExpectedContent);
@@ -139,7 +139,7 @@ describe('CGUs', function () {
       it('still records version for service B', async () => {
         const resultingTerms = await fs.readFile(
           path.resolve(__dirname, SERVICE_B_EXPECTED_VERSION_FILE_PATH),
-          { encoding: 'utf8' }
+          { encoding: 'utf8' },
         );
 
         expect(resultingTerms).to.equal(serviceBVersionExpectedContent);
@@ -168,11 +168,11 @@ describe('CGUs', function () {
           await app.init();
           await app.trackChanges(serviceIds);
 
-          const [originalSnapshotCommit] = await gitSnapshot().log({ file: SERVICE_A_EXPECTED_SNAPSHOT_FILE_PATH, });
+          const [originalSnapshotCommit] = await gitSnapshot().log({ file: SERVICE_A_EXPECTED_SNAPSHOT_FILE_PATH });
 
           originalSnapshotId = originalSnapshotCommit.hash;
 
-          const [firstVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH, });
+          const [firstVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH });
 
           firstVersionId = firstVersionCommit.hash;
 
@@ -182,7 +182,7 @@ describe('CGUs', function () {
 
           await app.refilterAndRecord([ 'service_A', 'service_B' ]);
 
-          const [refilterVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH, });
+          const [refilterVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH });
 
           refilterVersionId = refilterVersionCommit.hash;
           refilterVersionMessageBody = refilterVersionCommit.body;
@@ -193,7 +193,7 @@ describe('CGUs', function () {
         it('refilters the changed service', async () => {
           const serviceAContent = await fs.readFile(
             path.resolve(__dirname, SERVICE_A_EXPECTED_VERSION_FILE_PATH),
-            { encoding: 'utf8' }
+            { encoding: 'utf8' },
           );
 
           expect(serviceAContent).to.equal('Terms of service with UTF-8 \'çhãràčtęrs"\n========================================');
@@ -210,14 +210,14 @@ describe('CGUs', function () {
         it('does not change other services', async () => {
           const serviceBVersion = await fs.readFile(
             path.resolve(__dirname, SERVICE_B_EXPECTED_VERSION_FILE_PATH),
-            { encoding: 'utf8' }
+            { encoding: 'utf8' },
           );
 
           expect(serviceBVersion).to.equal(serviceBVersionExpectedContent);
         });
 
         it('does not generate a new id for other services', async () => {
-          const serviceBCommitsAfterRefiltering = await gitVersion().log({ file: SERVICE_B_EXPECTED_VERSION_FILE_PATH, });
+          const serviceBCommitsAfterRefiltering = await gitVersion().log({ file: SERVICE_B_EXPECTED_VERSION_FILE_PATH });
 
           expect(serviceBCommitsAfterRefiltering.map(commit => commit.hash)).to.deep.equal(serviceBCommits.map(commit => commit.hash));
         });
@@ -310,7 +310,7 @@ describe('CGUs', function () {
         it('emits "firstSnapshotRecorded" event', async () => {
           expect(spies.onFirstSnapshotRecorded).to.have.been.calledWith(
             SERVICE_A_ID,
-            SERVICE_A_TYPE
+            SERVICE_A_TYPE,
           );
         });
 
@@ -366,7 +366,7 @@ describe('CGUs', function () {
           it('emits "snapshotNotChanged" event', async () => {
             expect(spies.onSnapshotNotChanged).to.have.been.calledWith(
               SERVICE_A_ID,
-              SERVICE_A_TYPE
+              SERVICE_A_TYPE,
             );
           });
 
@@ -393,7 +393,7 @@ describe('CGUs', function () {
         it('emits "firstVersionRecorded" event', async () => {
           expect(spies.onFirstVersionRecorded).to.have.been.calledWith(
             SERVICE_A_ID,
-            SERVICE_A_TYPE
+            SERVICE_A_TYPE,
           );
         });
 
@@ -568,21 +568,21 @@ describe('CGUs', function () {
         it('emits "snapshotNotChanged" events', async () => {
           expect(spies.onSnapshotNotChanged).to.have.been.calledOnceWith(
             SERVICE_B_ID,
-            SERVICE_B_TYPE
+            SERVICE_B_TYPE,
           );
         });
 
         it('emits "snapshotRecorded" event for service which changed', async () => {
           expect(spies.onSnapshotRecorded).to.have.been.calledOnceWith(
             SERVICE_A_ID,
-            SERVICE_A_TYPE
+            SERVICE_A_TYPE,
           );
         });
 
         it('emits "versionNotChanged" events', async () => {
           expect(spies.onVersionNotChanged).to.have.been.calledOnceWith(
             SERVICE_B_ID,
-            SERVICE_B_TYPE
+            SERVICE_B_TYPE,
           );
         });
 

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -168,15 +168,11 @@ describe('CGUs', function () {
           await app.init();
           await app.trackChanges(serviceIds);
 
-          const [originalSnapshotCommit] = await gitSnapshot().log({
-            file: SERVICE_A_EXPECTED_SNAPSHOT_FILE_PATH,
-          });
+          const [originalSnapshotCommit] = await gitSnapshot().log({ file: SERVICE_A_EXPECTED_SNAPSHOT_FILE_PATH, });
 
           originalSnapshotId = originalSnapshotCommit.hash;
 
-          const [firstVersionCommit] = await gitVersion().log({
-            file: SERVICE_A_EXPECTED_VERSION_FILE_PATH,
-          });
+          const [firstVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH, });
 
           firstVersionId = firstVersionCommit.hash;
 
@@ -186,9 +182,7 @@ describe('CGUs', function () {
 
           await app.refilterAndRecord([ 'service_A', 'service_B' ]);
 
-          const [refilterVersionCommit] = await gitVersion().log({
-            file: SERVICE_A_EXPECTED_VERSION_FILE_PATH,
-          });
+          const [refilterVersionCommit] = await gitVersion().log({ file: SERVICE_A_EXPECTED_VERSION_FILE_PATH, });
 
           refilterVersionId = refilterVersionCommit.hash;
           refilterVersionMessageBody = refilterVersionCommit.body;
@@ -223,9 +217,7 @@ describe('CGUs', function () {
         });
 
         it('does not generate a new id for other services', async () => {
-          const serviceBCommitsAfterRefiltering = await gitVersion().log({
-            file: SERVICE_B_EXPECTED_VERSION_FILE_PATH,
-          });
+          const serviceBCommitsAfterRefiltering = await gitVersion().log({ file: SERVICE_B_EXPECTED_VERSION_FILE_PATH, });
 
           expect(serviceBCommitsAfterRefiltering.map(commit => commit.hash)).to.deep.equal(serviceBCommits.map(commit => commit.hash));
         });

--- a/src/app/services/documentDeclaration.test.js
+++ b/src/app/services/documentDeclaration.test.js
@@ -48,7 +48,7 @@ describe('DocumentDeclaration', () => {
     context('With "remove" property', () => {
       context('With string selector', () => {
         it('extracts selectors', async () => {
-          const result = new DocumentDeclaration({ noiseSelectors: 'body', }).getCssSelectors();
+          const result = new DocumentDeclaration({ noiseSelectors: 'body' }).getCssSelectors();
 
           expect(result).to.deep.equal(['body']);
         });

--- a/src/app/services/documentDeclaration.test.js
+++ b/src/app/services/documentDeclaration.test.js
@@ -48,9 +48,7 @@ describe('DocumentDeclaration', () => {
     context('With "remove" property', () => {
       context('With string selector', () => {
         it('extracts selectors', async () => {
-          const result = new DocumentDeclaration({
-            noiseSelectors: 'body',
-          }).getCssSelectors();
+          const result = new DocumentDeclaration({ noiseSelectors: 'body', }).getCssSelectors();
 
           expect(result).to.deep.equal(['body']);
         });

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -13,7 +13,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SERVICE_DECLARATIONS_PATH = path.resolve(
   __dirname,
   '../../..',
-  config.get('serviceDeclarationsPath')
+  config.get('serviceDeclarationsPath'),
 );
 
 export async function load() {
@@ -150,7 +150,7 @@ async function loadServiceHistoryFiles(serviceId) {
   const serviceFiltersFileName = path.join(SERVICE_DECLARATIONS_PATH, `${serviceId}.filters.js`);
   const serviceFiltersHistoryFileName = path.join(
     SERVICE_DECLARATIONS_PATH,
-    `${serviceId}.filters.history.js`
+    `${serviceId}.filters.history.js`,
   );
 
   let serviceHistory = {};

--- a/src/app/services/index.test.js
+++ b/src/app/services/index.test.js
@@ -70,7 +70,7 @@ describe('Services', () => {
       describe('Service wihout history', async () => {
         await validateServiceWithoutHistory(
           'service_without_history',
-          expectedServices.service_without_history
+          expectedServices.service_without_history,
         );
       });
     });
@@ -78,7 +78,7 @@ describe('Services', () => {
       describe('Service with declaration history', async () => {
         await validateServiceWithoutHistory(
           'service_with_declaration_history',
-          expectedServices.service_with_declaration_history
+          expectedServices.service_with_declaration_history,
         );
       });
     });
@@ -86,7 +86,7 @@ describe('Services', () => {
       describe('Service with filters history', async () => {
         await validateServiceWithoutHistory(
           'service_with_filters_history',
-          expectedServices.service_with_filters_history
+          expectedServices.service_with_filters_history,
         );
       });
     });
@@ -94,7 +94,7 @@ describe('Services', () => {
       describe('Service with history', async () => {
         await validateServiceWithoutHistory(
           'service_with_history',
-          expectedServices.service_with_history
+          expectedServices.service_with_history,
         );
       });
     });
@@ -123,7 +123,7 @@ describe('Services', () => {
                   it('has the proper number of filter functions', async () => {
                     const actualDocument = result[serviceId].getDocumentDeclaration(
                       documentType,
-                      date
+                      date,
                     );
 
                     expect(actualDocument.filters.length).to.equal(expectedDocument.filters.length);
@@ -137,7 +137,7 @@ describe('Services', () => {
                     it(`has the proper "${expectedDocument.filters[indexFilter].name}" filter function`, async () => {
                       const actualDocument = result[serviceId].getDocumentDeclaration(
                         documentType,
-                        date
+                        date,
                       );
 
                       expect(await actualDocument.filters[indexFilter]()).equal(await expectedDocument.filters[indexFilter]()); // eslint-disable-line no-await-in-loop
@@ -147,7 +147,7 @@ describe('Services', () => {
                   it('has no filters', () => {
                     const actualDocument = result[serviceId].getDocumentDeclaration(
                       documentType,
-                      date
+                      date,
                     );
 
                     expect(actualDocument.filters).to.be.undefined;
@@ -210,7 +210,7 @@ describe('Services', () => {
       describe('Service wihout history', async () => {
         await validateServiceWithHistory(
           'service_without_history',
-          expectedServices.service_without_history
+          expectedServices.service_without_history,
         );
       });
     });
@@ -218,7 +218,7 @@ describe('Services', () => {
       describe('Service with declaration history', async () => {
         await validateServiceWithHistory(
           'service_with_declaration_history',
-          expectedServices.service_with_declaration_history
+          expectedServices.service_with_declaration_history,
         );
       });
     });
@@ -226,7 +226,7 @@ describe('Services', () => {
       describe('Service with filters history', async () => {
         await validateServiceWithHistory(
           'service_with_filters_history',
-          expectedServices.service_with_filters_history
+          expectedServices.service_with_filters_history,
         );
       });
     });
@@ -234,7 +234,7 @@ describe('Services', () => {
       describe('Service with history', async () => {
         await validateServiceWithHistory(
           'service_with_history',
-          expectedServices.service_with_history
+          expectedServices.service_with_history,
         );
       });
     });

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -18,7 +18,7 @@ const alignedWithColorsAndTime = combine(
     }
 
     return `${timestamp} ${level.padEnd(15)} ${prefix.padEnd(55)} ${message}`;
-  })
+  }),
 );
 
 const consoleTransport = new winston.transports.Console();

--- a/src/notifier/index.js
+++ b/src/notifier/index.js
@@ -89,7 +89,7 @@ export default class Notifier {
         'lists',
         lists,
         count,
-        offset + limit
+        offset + limit,
       ),
     };
   }
@@ -110,7 +110,7 @@ export default class Notifier {
       listId,
       'contacts',
       [],
-      list.totalSubscribers
+      list.totalSubscribers,
     );
   }
 
@@ -121,7 +121,7 @@ export default class Notifier {
     accumulator,
     count,
     offset = 0,
-    paginationSize = 50
+    paginationSize = 50,
   ) {
     if (accumulator.length >= count) {
       return accumulator;
@@ -145,7 +145,7 @@ export default class Notifier {
       accumulator,
       count,
       offset + paginationSize,
-      paginationSize
+      paginationSize,
     );
   }
 }

--- a/test/fixtures/service_A.js
+++ b/test/fixtures/service_A.js
@@ -16,6 +16,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = { 'Terms of Service': { _latest: latest, }, };
+service._documents = { 'Terms of Service': { _latest: latest } };
 
 export default service;

--- a/test/fixtures/service_A.js
+++ b/test/fixtures/service_A.js
@@ -16,10 +16,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = {
-  'Terms of Service': {
-    _latest: latest,
-  },
-};
+service._documents = { 'Terms of Service': { _latest: latest, }, };
 
 export default service;

--- a/test/fixtures/service_B.js
+++ b/test/fixtures/service_B.js
@@ -16,6 +16,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = { 'Privacy Policy': { _latest: latest, }, };
+service._documents = { 'Privacy Policy': { _latest: latest } };
 
 export default service;

--- a/test/fixtures/service_B.js
+++ b/test/fixtures/service_B.js
@@ -16,10 +16,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = {
-  'Privacy Policy': {
-    _latest: latest,
-  },
-};
+service._documents = { 'Privacy Policy': { _latest: latest, }, };
 
 export default service;

--- a/test/fixtures/service_without_history.js
+++ b/test/fixtures/service_without_history.js
@@ -25,10 +25,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = {
-  'Terms of Service': {
-    _latest: latest,
-  },
-};
+service._documents = { 'Terms of Service': { _latest: latest, }, };
 
 export default service;

--- a/test/fixtures/service_without_history.js
+++ b/test/fixtures/service_without_history.js
@@ -25,6 +25,6 @@ const latest = new DocumentDeclaration({
   validUntil: null,
 });
 
-service._documents = { 'Terms of Service': { _latest: latest, }, };
+service._documents = { 'Terms of Service': { _latest: latest } };
 
 export default service;


### PR DESCRIPTION
Fixes #663 

- Update `object-curly-newline` and `comma-dangle` rules.
- Remove warning on tests files
- Remove errors on scripts files