### PR TITLE
Close github issue as soon as a snapshot is retrieved, even if it's the same as before

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -88,14 +88,13 @@ rules:
     - separate-lines
 
 overrides:
-- files:
-  - src/**/*test.js
-  - scripts/validation/*.js
-  rules:
-    func-names: 0
-- files:
-  - scripts/**/*.js
-  rules:
-    func-names: 0
-    import/no-extraneous-dependencies: 0
-
+  - files:
+      - src/**/*test.js
+      - scripts/validation/*.js
+    rules:
+      func-names: 0
+  - files:
+      - scripts/**/*.js
+    rules:
+      func-names: 0
+      import/no-extraneous-dependencies: 0

--- a/src/github/index.js
+++ b/src/github/index.js
@@ -49,6 +49,14 @@ export default class GitHub {
     });
   }
 
+  async onSnapshotNotChanged(serviceId, type) {
+    await this.closeIssueIfExists({
+      labels: [UPDATE_DOCUMENT_LABEL],
+      title: `Fix ${serviceId} - ${type}`,
+      comment: '🤖 Closed automatically as snapshot is unchanged but data has been fetched correctly',
+    });
+  }
+
   async onFirstVersionRecorded(serviceId, type) {
     return this.onVersionRecorded(serviceId, type);
   }


### PR DESCRIPTION
This way, a lot of github issues should be fixed in `OpenTermsArchive/services-all`