### PR TITLE
Remove “prod” options from NPM scripts

### DIFF
--- a/ops/roles/ota/tasks/main.yml
+++ b/ops/roles/ota/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: Start Open Terms Archive
   command:
-    cmd: pm2 start --name "{{ app }}" --exp-backoff-restart-delay=1000 npm -- run start:scheduler:prod
+    cmd: pm2 start --name "{{ app }}" --exp-backoff-restart-delay=1000 npm -- run start:scheduler
     chdir: '/home/{{ ansible_user }}/{{ app }}'
   environment:
     NODE_ENV: production

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   },
   "scripts": {
     "start": "node --max-http-header-size=32768 src/index.js",
-    "start:prod": "cross-env NODE_ENV=production node --max-http-header-size=32768 src/index.js",
     "start:scheduler": "node --max-http-header-size=32768 src/index.js --schedule",
-    "start:scheduler:prod": "cross-env NODE_ENV=production node --max-http-header-size=32768 src/index.js --schedule",
     "test": "cross-env NODE_ENV=test mocha --recursive \"./src/**/*.test.js\" --exit",
     "test:debug": "npm run test -- --inspect-brk --exit",
     "posttest": "npm run lint",


### PR DESCRIPTION
Consider that Ansible manages production environments, not NPM scripts. This allows other environments to be considered as “production”: otherwise, Ansible sets up pm2 to use `npm start:prod` and its `NODE_ENV` is ignored.

I did not ship this as a fix, even though it is needed for deploying different instances, because removing the `:prod` options from NPM scripts altogether might impact other developers in ways I can not foresee.