### PR TITLE
Do not assume Git repositories exist as databases

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "validate:schema": "npm run validate -- --schema-only",
     "export": "node scripts/export/makedataset.js",
     "release": "node scripts/release/build_release.js",
-    "refilter": "node src/index.js --refilter-only",
-    "sync-git": "cd data/versions && git fetch && git reset --hard origin/master && cd ../snapshots && git fetch && git reset --hard origin/master"
+    "refilter": "node src/index.js --refilter-only"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove a handy npm script that is not that handy anymore after #682 and that makes too many assumptions on directories.