### PR TITLE
Improve CI and CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - run: git checkout HEAD
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - run: echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault.key
-      - run: |
-          git config --global user.name 'Open Terms Archive Bot'
-          git config --global user.email 'bot@opentermsarchive.org'
       - run: pip install --upgrade setuptools
       - run: pip install ansible==2.9.11
       - run: ansible-playbook ops/site.yml --inventory ops/inventories/production.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,5 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - run: echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault.key
       - run: pip install --upgrade setuptools
-      - run: pip install ansible==2.9.11
+      - run: pip install 'ansible ~= 2.9'
       - run: ansible-playbook ops/site.yml --inventory ops/inventories/production.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
-          key: ${{ secrets.SSH_KEY }}
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-      - run: echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault.key
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          known_hosts: ${{ secrets.SERVER_FINGERPRINT }}
+      - run: echo "${{ secrets.ANSIBLE_VAULT_KEY }}" > vault.key
       - run: pip install --upgrade setuptools
       - run: pip install 'ansible ~= 2.9'
       - run: ansible-playbook ops/site.yml --inventory ops/inventories/production.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           repository: OpenTermsArchive/services-all
           path: ./services-all
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - name: Install and Start MongoDB (ubuntu)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 14
       - name: Install and Start MongoDB (ubuntu)
         if: matrix.operating_system == 'ubuntu-latest'
         uses: supercharge/mongodb-github-action@1.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,7 @@ jobs:
           git config --global user.email 'bot@opentermsarchive.org'
           git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: OpenTermsArchive/services-all
-          path: ./services-all
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - name: Install and Start MongoDB (ubuntu)
@@ -42,5 +37,24 @@ jobs:
         with:
           args: install mongodb
       - run: npm ci
-      - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run validate:schema
       - run: npm test
+
+  validate_declarations:
+    strategy:
+      matrix:
+        operating_system: [ubuntu-latest, windows-2019]
+      fail-fast: false # run tests on other operating systems even if one fails
+
+    runs-on: ${{ matrix.operating_system }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: OpenTermsArchive/services-all
+          path: ./services-all
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: npm ci
+      - run: ./node_modules/.bin/cross-env NODE_ENV=ci npm run validate:schema


### PR DESCRIPTION
This changeset:

- Speeds up continuous testing from an average 3m30s to 2m20s.
- Relaxes Ansible version constraints and thus fixes [a bug](https://github.com/ansible/ansible/pull/71824) [we encounter](https://github.com/ambanum/OpenTermsArchive/runs/4715351606?check_suite_focus=true) on some deployments.
- Increases readability and maintainability of the CI pipeline.

### Modified secret names

The `ANSIBLE_VAULT_KEY` secret is defined at organization level in @OpenTermsArchive so it can be exposed to other repositories that also need it for deployment, like `services-dating`. Until this repository migrates there, I defined that secret at repository level.
I already defined `SERVER_SSH_KEY` in the repository secrets, assuming this PR would get merged. If it does not, this secret should be erased. That key has fingerprint `SHA256:bUADsRkQFPMYMtQrOsoI4GeCxsP3+iDz9x4GiX0IM4k` and is a new one that I added to the server’s `authorized_keys` as well as to @OTA-Bot’s keys.
I also defined `SERVER_FINGERPRINT`, it is just a renaming of `KNOWN_HOSTS`.

If this PR gets merged, all previous secrets should be erased.