### PR TITLE
Throw inacessible content when data found is empty

### DIFF
--- a/src/archivist/recorder/index.js
+++ b/src/archivist/recorder/index.js
@@ -1,3 +1,5 @@
+import { InaccessibleContentError } from '../errors.js';
+
 export default class Recorder {
   constructor({ versionsStorageAdapter, snapshotsStorageAdapter }) {
     if (!versionsStorageAdapter || !snapshotsStorageAdapter) {
@@ -34,7 +36,7 @@ export default class Recorder {
     }
 
     if (!content) {
-      throw new Error('A document content is required');
+      throw new InaccessibleContentError('A document content is required');
     }
 
     if (!mimeType) {
@@ -62,7 +64,7 @@ export default class Recorder {
     }
 
     if (!content) {
-      throw new Error('A document content is required');
+      throw new InaccessibleContentError('A document content is required');
     }
 
     return this.versionsStorageAdapter.record({ serviceId, documentType, snapshotId, fetchDate, content });


### PR DESCRIPTION
For now, it is only an Error that is thrown and everytime it happens, it kills the PID
Here, we consider having an empty content is an inaccesible content error