### PR TITLE
Add ability to customize language requests for instance

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,8 @@
   },
   "fetcher": {
     "waitForElementsTimeout": 10000,
-    "navigationTimeout": 30000
+    "navigationTimeout": 30000,
+    "language": "en"
   },
   "logger": {
     "smtp": {

--- a/config/ota-services-france-production.json
+++ b/config/ota-services-france-production.json
@@ -29,6 +29,9 @@
       }
     }
   },
+  "fetcher": {
+    "language": "fr"
+  },
   "logger": {
     "sendMailOnError": {
       "to": "admin@opentermsarchive.org",

--- a/src/archivist/fetcher/fullDomFetcher.js
+++ b/src/archivist/fetcher/fullDomFetcher.js
@@ -9,6 +9,7 @@ puppeteer.use(StealthPlugin());
 
 const NAVIGATION_TIMEOUT = config.get('fetcher.navigationTimeout');
 const WAIT_FOR_ELEMENTS_TIMEOUT = config.get('fetcher.waitForElementsTimeout');
+const LANGUAGE = config.get('fetcher.language');
 
 let browser;
 
@@ -23,8 +24,10 @@ export default async function fetch(url, cssSelectors) {
 
   try {
     page = await browser.newPage();
+
     await page.setUserAgent(new UserAgent().toString());
     await page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT);
+    await page.setExtraHTTPHeaders({ 'Accept-Language': LANGUAGE });
 
     response = await page.goto(url, { waitUntil: 'networkidle0' });
 

--- a/src/archivist/fetcher/htmlOnlyFetcher.js
+++ b/src/archivist/fetcher/htmlOnlyFetcher.js
@@ -6,8 +6,8 @@ import nodeFetch, { AbortError } from 'node-fetch';
 
 import { FetchDocumentError } from './errors.js';
 
-const LANGUAGE = 'en';
 const NAVIGATION_TIMEOUT = config.get('fetcher.navigationTimeout');
+const LANGUAGE = config.get('fetcher.language');
 
 export default async function fetch(url) {
   const controller = new AbortController();


### PR DESCRIPTION
On UFC instance, we always want to retrieve french version of documents.

For this, it is sometimes necesary to pass a request header.