### PR TITLE
Prevent scheduled jobs from running multiple times in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "mocha": "^9.1.3",
         "mongodb": "^4.2.0",
         "node-fetch": "^3.1.0",
-        "node-schedule": "^2.0.0",
         "octokit": "^1.7.0",
         "pdfjs-dist": "^2.9.359",
         "puppeteer": "^11.0.0",
@@ -95,6 +94,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/semver": {
@@ -267,7 +271,10 @@
     "node_modules/@accordproject/markdown-pdf/node_modules/pdfjs-dist": {
       "version": "2.8.335",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.8.335.tgz",
-      "integrity": "sha512-2IKw7wP1RnzzWJcpkeZwF+cKROFiQext+/WburB6cgKwt9zc8rOyDH7a3FepdcciSGs8SDs/AuWe8qVx+iI6pw=="
+      "integrity": "sha512-2IKw7wP1RnzzWJcpkeZwF+cKROFiQext+/WburB6cgKwt9zc8rOyDH7a3FepdcciSGs8SDs/AuWe8qVx+iI6pw==",
+      "peerDependencies": {
+        "worker-loader": "^3.0.7"
+      }
     },
     "node_modules/@accordproject/markdown-template": {
       "version": "0.14.1",
@@ -343,6 +350,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@foliojs-fork/fontkit": {
@@ -593,6 +605,9 @@
       "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
       "dependencies": {
         "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -602,6 +617,9 @@
       "dependencies": {
         "@octokit/types": "^6.34.0",
         "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-retry": {
@@ -620,6 +638,9 @@
       "dependencies": {
         "@octokit/types": "^6.0.1",
         "bottleneck": "^2.15.3"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^3.5.0"
       }
     },
     "node_modules/@octokit/request": {
@@ -886,7 +907,10 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn-node": {
       "version": "1.8.2",
@@ -943,6 +967,10 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/amdefine": {
@@ -979,6 +1007,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ansi-styles/node_modules/color-convert": {
@@ -1041,6 +1072,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/es-abstract": {
@@ -1072,6 +1106,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/has-symbols": {
@@ -1081,6 +1118,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/is-callable": {
@@ -1090,6 +1130,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/is-regex": {
@@ -1103,13 +1146,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array-includes/node_modules/object.assign": {
       "version": "4.1.2",
@@ -1124,6 +1173,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/string.prototype.trimend": {
@@ -1134,6 +1186,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/string.prototype.trimstart": {
@@ -1144,6 +1199,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -1158,6 +1216,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/es-abstract": {
@@ -1189,6 +1250,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/has-symbols": {
@@ -1198,6 +1262,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/is-callable": {
@@ -1207,6 +1274,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/is-regex": {
@@ -1220,13 +1290,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/array.prototype.flat/node_modules/object.assign": {
       "version": "4.1.2",
@@ -1241,6 +1317,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/string.prototype.trimend": {
@@ -1251,6 +1330,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/string.prototype.trimstart": {
@@ -1261,6 +1343,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assertion-error": {
@@ -1513,6 +1598,20 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1547,7 +1646,21 @@
     "node_modules/buffer/node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -1556,6 +1669,9 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1573,6 +1689,9 @@
       "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -1597,6 +1716,9 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dependencies": {
         "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chai-exclude": {
@@ -1605,6 +1727,9 @@
       "integrity": "sha512-IBnm50Mvl3O1YhPpTgbU8MK0Gw7NHcb18WT2TxGdPKOMtdtZVKLHmQwdvOF7mTlHVQStbXuZKFwkevFtbHjpVg==",
       "dependencies": {
         "fclone": "^1.0.11"
+      },
+      "peerDependencies": {
+        "chai": ">= 4.0.0 < 5"
       }
     },
     "node_modules/chalk": {
@@ -1617,6 +1742,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/ansi-styles": {
@@ -1628,6 +1756,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/color-convert": {
@@ -1872,18 +2003,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "node_modules/cron-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.1.0.tgz",
-      "integrity": "sha512-4Spe1gRbiQza3BqklhB/8dMi8PZAWalhLK1p+k3iYJjcxIK6t4YYGL0lKdHT0e743jDTJEDBz1NEAzY88kyNWQ==",
-      "dependencies": {
-        "is-nan": "^1.3.0",
-        "luxon": "^1.25.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -1999,6 +2118,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -2030,6 +2150,9 @@
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -2254,7 +2377,10 @@
     "node_modules/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-variable": {
       "version": "0.0.6",
@@ -2273,6 +2399,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es5-ext": {
@@ -2425,6 +2554,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-airbnb-base": {
@@ -2440,6 +2572,10 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.2"
       }
     },
     "node_modules/eslint-config-airbnb-base/node_modules/object.assign": {
@@ -2455,6 +2591,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-config-airbnb-base/node_modules/semver": {
@@ -2493,6 +2632,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -2537,6 +2679,9 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -2561,6 +2706,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -2610,6 +2758,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -2644,6 +2795,12 @@
       },
       "engines": {
         "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
@@ -2683,6 +2840,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -2692,6 +2854,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
@@ -2960,6 +3125,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3004,6 +3172,16 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
       "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
       "dependencies": {
         "web-streams-polyfill": "^3.0.3"
       },
@@ -3066,6 +3244,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up/node_modules/p-locate": {
@@ -3123,8 +3304,19 @@
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-in": {
@@ -3173,12 +3365,30 @@
     "node_modules/formidable": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -3207,6 +3417,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3255,6 +3466,9 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-symbol-description": {
@@ -3268,6 +3482,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -3284,6 +3501,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3307,6 +3527,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -3337,7 +3560,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -3353,6 +3579,9 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-tostringtag": {
@@ -3364,6 +3593,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-tostringtag/node_modules/has-symbols": {
@@ -3372,6 +3604,9 @@
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/he": {
@@ -3448,7 +3683,21 @@
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -3484,6 +3733,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -3541,6 +3793,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-bigint": {
@@ -3550,6 +3805,9 @@
       "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-binary-path": {
@@ -3574,6 +3832,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -3583,6 +3844,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -3591,6 +3855,9 @@
       "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-date-object": {
@@ -3599,6 +3866,9 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extendable": {
@@ -3628,18 +3898,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -3647,6 +3905,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -3667,6 +3928,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3703,13 +3967,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-stream": {
       "version": "1.1.0",
@@ -3729,6 +3999,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-symbol": {
@@ -3741,6 +4014,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3749,6 +4025,9 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakref": {
@@ -3758,6 +4037,9 @@
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -3834,6 +4116,14 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsdom/node_modules/abab": {
@@ -3956,6 +4246,18 @@
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsdom/node_modules/xml-name-validator": {
@@ -4051,8 +4353,10 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -4247,6 +4551,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/logform": {
@@ -4260,11 +4567,6 @@
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
       }
-    },
-    "node_modules/long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
     },
     "node_modules/lorem-ipsum": {
       "version": "2.0.3",
@@ -4290,14 +4592,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/magic-string": {
@@ -4489,6 +4783,10 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
       }
     },
     "node_modules/mocha/node_modules/debug": {
@@ -4500,6 +4798,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/mocha/node_modules/debug/node_modules/ms": {
@@ -4513,6 +4816,9 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/find-up": {
@@ -4525,6 +4831,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/glob": {
@@ -4541,6 +4850,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/locate-path": {
@@ -4552,6 +4864,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -4568,6 +4883,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/p-locate": {
@@ -4579,6 +4897,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mongodb": {
@@ -4704,19 +5025,10 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/node-schedule": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.0.0.tgz",
-      "integrity": "sha512-cHc9KEcfiuXxYDU+HjsBVo2FkWL1jRAUoczFoMIzRBpOA4p/NRHuuLs85AWOLgKsHtSPjN8csvwIxc2SqMv+CQ==",
-      "dependencies": {
-        "cron-parser": "^3.1.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
       },
-      "engines": {
-        "node": ">=6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-path": {
@@ -4735,7 +5047,10 @@
     "node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-is": {
       "version": "1.1.5",
@@ -4747,6 +5062,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-keys": {
@@ -4800,6 +5118,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/has-symbols": {
@@ -4809,6 +5130,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/is-callable": {
@@ -4818,6 +5142,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/is-regex": {
@@ -4831,13 +5158,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object.entries/node_modules/object.assign": {
       "version": "4.1.2",
@@ -4852,6 +5185,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/string.prototype.trimend": {
@@ -4862,6 +5198,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries/node_modules/string.prototype.trimstart": {
@@ -4872,6 +5211,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
@@ -4886,6 +5228,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/es-abstract": {
@@ -4917,6 +5262,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/has-symbols": {
@@ -4926,6 +5274,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/is-callable": {
@@ -4935,6 +5286,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/is-regex": {
@@ -4948,13 +5302,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object.values/node_modules/object.assign": {
       "version": "4.1.2",
@@ -4969,6 +5329,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/string.prototype.trimend": {
@@ -4979,6 +5342,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/string.prototype.trimstart": {
@@ -4989,6 +5355,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/octokit": {
@@ -5150,7 +5519,10 @@
     "node_modules/pdfjs-dist": {
       "version": "2.9.359",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.9.359.tgz",
-      "integrity": "sha512-P2nYtkacdlZaNNwrBLw1ZyMm0oE2yY/5S/GDCAmMJ7U4+ciL/D0mrlEC/o4HZZc/LNE3w8lEVzBEyVgEQlPVKQ=="
+      "integrity": "sha512-P2nYtkacdlZaNNwrBLw1ZyMm0oE2yY/5S/GDCAmMJ7U4+ciL/D0mrlEC/o4HZZc/LNE3w8lEVzBEyVgEQlPVKQ==",
+      "peerDependencies": {
+        "worker-loader": "^3.0.7"
+      }
     },
     "node_modules/pdfmake": {
       "version": "0.2.4",
@@ -5188,6 +5560,9 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pkg-dir": {
@@ -5292,6 +5667,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-11.0.0.tgz",
       "integrity": "sha512-6rPFqN1ABjn4shgOICGDBITTRV09EjXVqhDERBDKwCLz0UyBxeeBH6Ay0vQUJ84VACmlxwzOIzVEJXThcF3aNg==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
       "hasInstallScript": true,
       "dependencies": {
         "debug": "4.3.2",
@@ -5323,6 +5699,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "peerDependencies": {
+        "puppeteer": "*"
       }
     },
     "node_modules/puppeteer-extra-plugin": {
@@ -5336,6 +5715,9 @@
       },
       "engines": {
         "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "puppeteer-extra": "*"
       }
     },
     "node_modules/puppeteer-extra-plugin-stealth": {
@@ -5400,6 +5782,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/puppeteer/node_modules/node-fetch": {
@@ -5449,6 +5836,18 @@
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "engines": {
         "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/qs": {
@@ -5545,6 +5944,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -5554,6 +5956,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {
@@ -5571,6 +5976,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -5599,12 +6007,29 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5755,13 +6180,19 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel/node_modules/object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/simple-git": {
       "version": "2.47.0",
@@ -5782,6 +6213,11 @@
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/simple-swizzle": {
@@ -5809,13 +6245,21 @@
         "diff": "^5.0.0",
         "nise": "^5.1.0",
         "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/sinon-chai": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
     },
     "node_modules/sinon/node_modules/has-flag": {
       "version": "4.0.0",
@@ -5845,11 +6289,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -5990,12 +6429,16 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/superagent": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
       "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
       "dependencies": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -6040,6 +6483,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-color/node_modules/has-flag": {
@@ -6097,7 +6543,8 @@
     "node_modules/text-encoding": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained"
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -6219,6 +6666,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-of": {
@@ -6246,6 +6696,9 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unbox-primitive/node_modules/has-symbols": {
@@ -6255,6 +6708,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unbzip2-stream": {
@@ -6440,6 +6896,9 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/winston": {
@@ -6471,6 +6930,9 @@
       },
       "engines": {
         "node": ">= 0.6.0"
+      },
+      "peerDependencies": {
+        "winston": ">=0.5.0"
       }
     },
     "node_modules/winston-transport": {
@@ -6543,6 +7005,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -6637,6 +7102,9 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yauzl": {
@@ -6654,6 +7122,9 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -6823,7 +7294,8 @@
         "pdfjs-dist": {
           "version": "2.8.335",
           "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.8.335.tgz",
-          "integrity": "sha512-2IKw7wP1RnzzWJcpkeZwF+cKROFiQext+/WburB6cgKwt9zc8rOyDH7a3FepdcciSGs8SDs/AuWe8qVx+iI6pw=="
+          "integrity": "sha512-2IKw7wP1RnzzWJcpkeZwF+cKROFiQext+/WburB6cgKwt9zc8rOyDH7a3FepdcciSGs8SDs/AuWe8qVx+iI6pw==",
+          "requires": {}
         }
       }
     },
@@ -7417,7 +7889,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -8250,15 +8723,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cron-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.1.0.tgz",
-      "integrity": "sha512-4Spe1gRbiQza3BqklhB/8dMi8PZAWalhLK1p+k3iYJjcxIK6t4YYGL0lKdHT0e743jDTJEDBz1NEAzY88kyNWQ==",
-      "requires": {
-        "is-nan": "^1.3.0",
-        "luxon": "^1.25.0"
-      }
-    },
     "cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -8913,7 +9377,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz",
       "integrity": "sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-import": {
       "version": "2.25.3",
@@ -9669,15 +10134,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
-    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -9918,7 +10374,8 @@
         "ws": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "requires": {}
         },
         "xml-name-validator": {
           "version": "4.0.0",
@@ -10191,11 +10648,6 @@
         "triple-beam": "^1.3.0"
       }
     },
-    "long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
-    },
     "lorem-ipsum": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.3.tgz",
@@ -10211,11 +10663,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "luxon": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
     "magic-string": {
       "version": "0.25.1",
@@ -10540,16 +10987,6 @@
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.2",
         "formdata-polyfill": "^4.0.10"
-      }
-    },
-    "node-schedule": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.0.0.tgz",
-      "integrity": "sha512-cHc9KEcfiuXxYDU+HjsBVo2FkWL1jRAUoczFoMIzRBpOA4p/NRHuuLs85AWOLgKsHtSPjN8csvwIxc2SqMv+CQ==",
-      "requires": {
-        "cron-parser": "^3.1.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
       }
     },
     "normalize-path": {
@@ -10917,7 +11354,8 @@
     "pdfjs-dist": {
       "version": "2.9.359",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.9.359.tgz",
-      "integrity": "sha512-P2nYtkacdlZaNNwrBLw1ZyMm0oE2yY/5S/GDCAmMJ7U4+ciL/D0mrlEC/o4HZZc/LNE3w8lEVzBEyVgEQlPVKQ=="
+      "integrity": "sha512-P2nYtkacdlZaNNwrBLw1ZyMm0oE2yY/5S/GDCAmMJ7U4+ciL/D0mrlEC/o4HZZc/LNE3w8lEVzBEyVgEQlPVKQ==",
+      "requires": {}
     },
     "pdfmake": {
       "version": "0.2.4",
@@ -11091,7 +11529,8 @@
         "ws": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "requires": {}
         }
       }
     },
@@ -11495,17 +11934,13 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-    },
-    "sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "mocha": "^9.1.3",
     "mongodb": "^4.2.0",
     "node-fetch": "^3.1.0",
-    "node-schedule": "^2.0.0",
     "octokit": "^1.7.0",
     "pdfjs-dist": "^2.9.359",
     "puppeteer": "^11.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import config from 'config';
-import scheduler from 'node-schedule';
 
 import { publishRelease } from '../scripts/release/releasedataset.js';
 
@@ -71,18 +70,23 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
   }
 
   logger.info('The scheduler is running…');
-  logger.info('Documents will be tracked at minute 30 past every 6 hours.');
-  scheduler.scheduleJob('30 */6 * * *', async () => {
+
+  const TRACK_CHANGES_HOURS_INTERVAL = 2;
+  const RELEASE_HOURS_INTERVAL = 24;
+
+  logger.info(`Documents will be tracked every ${TRACK_CHANGES_HOURS_INTERVAL} hours\n`);
+  setInterval(async () => {
     await archivist.trackChanges(serviceIds);
-  });
+  }, TRACK_CHANGES_HOURS_INTERVAL * 60 * 60 * 1000);
 
   if (config.get('dataset.publish')) {
-    logger.info('Release will be created every 24 hours at 04h15');
-    scheduler.scheduleJob('15 4 * * *', async () => {
+    logger.info(`Release will be created every ${RELEASE_HOURS_INTERVAL} hours\n`);
+
+    setInterval(async () => {
       logger.info('Start creating the release…');
       await publishRelease();
       logger.info('Release published');
-    });
+    }, RELEASE_HOURS_INTERVAL * 60 * 60 * 1000);
   }
 }());
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
       const isServiceDeclared = archivist.serviceDeclarations[serviceId];
 
       if (!isServiceDeclared) {
-        logger.warn(`Parameter "${serviceId}" was interpreted as a service ID to update, but no matching declaration was found. It will be ignored`);
+        logger.warn(`Parameter "${serviceId}" was interpreted as a service ID to update, but no matching declaration was found; it will be ignored`);
       }
 
       return isServiceDeclared;
@@ -80,7 +80,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
   }, TRACK_CHANGES_HOURS_INTERVAL * 60 * 60 * 1000);
 
   if (config.get('dataset.publish')) {
-    logger.info(`Release will be created every ${RELEASE_HOURS_INTERVAL} hours\n`);
+    logger.info(`A release will be published every ${RELEASE_HOURS_INTERVAL} hours\n`);
 
     setInterval(async () => {
       logger.info('Start creating the release…');

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
   logger.info('The scheduler is running…');
 
-  const TRACK_CHANGES_HOURS_INTERVAL = 2;
-  const RELEASE_HOURS_INTERVAL = 24;
+  const TRACK_CHANGES_HOURS_INTERVAL = 24;
+  const RELEASE_HOURS_INTERVAL = 24 * 7;
 
   logger.info(`Documents will be tracked every ${TRACK_CHANGES_HOURS_INTERVAL} hours\n`);
   setInterval(async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
       const isServiceDeclared = archivist.serviceDeclarations[serviceId];
 
       if (!isServiceDeclared) {
-        logger.warn(`Parameter "${serviceId}" was interpreted as a service ID to update, but no matching declaration was found. It will be ignored.`);
+        logger.warn(`Parameter "${serviceId}" was interpreted as a service ID to update, but no matching declaration was found. It will be ignored`);
       }
 
       return isServiceDeclared;

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -98,8 +98,8 @@ logger.onRefilteringStarted = (numberOfServices, numberOfDocuments) => {
 };
 
 logger.onRefilteringCompleted = (numberOfServices, numberOfDocuments) => {
-  logger.info(`Examined ${numberOfDocuments} documents from ${numberOfServices} services for refiltering.`);
-  logger.info(`Recorded ${recordedVersionsCount} new versions.\n`);
+  logger.info(`Examined ${numberOfDocuments} documents from ${numberOfServices} services for refiltering`);
+  logger.info(`Recorded ${recordedVersionsCount} new versions\n`);
 };
 
 logger.onTrackingStarted = (numberOfServices, numberOfDocuments) => {
@@ -109,8 +109,8 @@ logger.onTrackingStarted = (numberOfServices, numberOfDocuments) => {
 };
 
 logger.onTrackingCompleted = (numberOfServices, numberOfDocuments) => {
-  logger.info(`Tracked changes of ${numberOfDocuments} documents from ${numberOfServices} services.`);
-  logger.info(`Recorded ${recordedSnapshotsCount} new snapshots and ${recordedVersionsCount} new versions.\n`);
+  logger.info(`Tracked changes of ${numberOfDocuments} documents from ${numberOfServices} services`);
+  logger.info(`Recorded ${recordedSnapshotsCount} new snapshots and ${recordedVersionsCount} new versions\n`);
 };
 
 logger.onInaccessibleContent = ({ message }, serviceId, type) => {


### PR DESCRIPTION
Should fix #756 and probably #753.

Notable changes:
- Remove `node-scheduler` dependency as it is [buggy](https://github.com/node-schedule/node-schedule/issues/635)
- Use native `setInterval` instead of using an external dependency
- Track changes every 6 hours instead of at minute 30 past every 6 hours

[`toad-scheduler`](https://github.com/kibertoad/toad-scheduler) and [`croner`](https://github.com/Hexagon/croner) were considered as `node-scheduler` replacement but native `setInterval` was chose for simplicity even if it does not offer same flexibility, but for now we do not need more than that.