### PR TITLE
Use Open Terms Archive user agent across fetcher implementations

### DIFF
--- a/src/archivist/fetcher/fullDomFetcher.js
+++ b/src/archivist/fetcher/fullDomFetcher.js
@@ -3,6 +3,7 @@ import puppeteer from 'puppeteer-extra';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
 
 import { FetchDocumentError } from './errors.js';
+import USER_AGENT from './userAgent.js';
 
 puppeteer.use(stealthPlugin());
 
@@ -24,6 +25,7 @@ export default async function fetch(url, cssSelectors) {
   try {
     page = await browser.newPage();
 
+    await page.setUserAgent(USER_AGENT);
     await page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT);
     await page.setExtraHTTPHeaders({ 'Accept-Language': LANGUAGE });
 

--- a/src/archivist/fetcher/htmlOnlyFetcher.js
+++ b/src/archivist/fetcher/htmlOnlyFetcher.js
@@ -5,6 +5,7 @@ import HttpsProxyAgent from 'https-proxy-agent';
 import nodeFetch, { AbortError } from 'node-fetch';
 
 import { FetchDocumentError } from './errors.js';
+import USER_AGENT from './userAgent.js';
 
 const NAVIGATION_TIMEOUT = config.get('fetcher.navigationTimeout');
 const LANGUAGE = config.get('fetcher.language');
@@ -16,7 +17,10 @@ export default async function fetch(url) {
   const options = {
     signal: controller.signal,
     credentials: 'include',
-    headers: { 'Accept-Language': LANGUAGE },
+    headers: {
+      'Accept-Language': LANGUAGE,
+      'User-Agent': USER_AGENT,
+    },
   };
 
   if (url.startsWith('https:') && process.env.HTTPS_PROXY) {

--- a/src/archivist/fetcher/userAgent.js
+++ b/src/archivist/fetcher/userAgent.js
@@ -1,0 +1,5 @@
+import { version } from '../../../package.json';
+
+const USER_AGENT = `OpenTermsArchive/${version}`;
+
+export default USER_AGENT;

--- a/src/archivist/fetcher/userAgent.js
+++ b/src/archivist/fetcher/userAgent.js
@@ -1,5 +1,5 @@
-import { version } from '../../../package.json';
+const PACKAGE_VERSION = require('../../../package.json').version;
 
-const USER_AGENT = `OpenTermsArchive/${version}`;
+const USER_AGENT = `OpenTermsArchive/${PACKAGE_VERSION}`;
 
 export default USER_AGENT;


### PR DESCRIPTION
Considering the lack of current problems on the HTML fetcher with no user agent at all, I doubt this would make things worse 🙂 