### PR TITLE
Allow loading only specified services

### DIFF
--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -35,12 +35,13 @@ let servicesToValidate = args;
 
 (async () => {
   const declarationsPath = path.resolve(__dirname, '../../', config.get('services.declarationsPath'));
-  const serviceDeclarations = await services.loadWithHistory();
 
   // If services to validate are passed as a string with services id separated by a newline character
   if (servicesToValidate.length == 1 && servicesToValidate[0].includes('\n')) {
     servicesToValidate = servicesToValidate[0].split('\n').filter(value => value);
   }
+
+  const serviceDeclarations = await services.loadWithHistory(servicesToValidate);
 
   if (!servicesToValidate.length) {
     servicesToValidate = Object.keys(serviceDeclarations);

--- a/src/archivist/services/index.test.js
+++ b/src/archivist/services/index.test.js
@@ -74,7 +74,7 @@ describe('Services', () => {
         );
       });
     });
-    context('when a service has only delcarations history', async () => {
+    context('when a service has only declarations history', async () => {
       describe('Service with declaration history', async () => {
         await validateServiceWithoutHistory(
           'service_with_declaration_history',
@@ -90,7 +90,7 @@ describe('Services', () => {
         );
       });
     });
-    context('when a service has both filters and delcarations histories', async () => {
+    context('when a service has both filters and declarations histories', async () => {
       describe('Service with history', async () => {
         await validateServiceWithoutHistory(
           'service_with_history',
@@ -224,7 +224,7 @@ describe('Services', () => {
         );
       });
     });
-    context('when a service has only delcarations history', async () => {
+    context('when a service has only declarations history', async () => {
       describe('Service with declaration history', async () => {
         await validateServiceWithHistory(
           'service_with_declaration_history',
@@ -240,7 +240,7 @@ describe('Services', () => {
         );
       });
     });
-    context('when a service has both filters and delcarations histories', async () => {
+    context('when a service has both filters and declarations histories', async () => {
       describe('Service with history', async () => {
         await validateServiceWithHistory(
           'service_with_history',

--- a/src/archivist/services/index.test.js
+++ b/src/archivist/services/index.test.js
@@ -98,6 +98,16 @@ describe('Services', () => {
         );
       });
     });
+
+    context('when specifying services to load', async () => {
+      before(async () => {
+        result = await services.load([ 'service_A', 'service_B' ]);
+      });
+
+      it('loads only the given services', async () => {
+        expect(result).to.have.all.keys('service_A', 'service_B');
+      });
+    });
   });
 
   describe('#loadWithHistory', () => {
@@ -236,6 +246,16 @@ describe('Services', () => {
           'service_with_history',
           expectedServices.service_with_history,
         );
+      });
+    });
+
+    context('when specifying services to load', async () => {
+      before(async () => {
+        result = await services.loadWithHistory([ 'service_A', 'service_B' ]);
+      });
+
+      it('loads only the given services', async () => {
+        expect(result).to.have.all.keys('service_A', 'service_B');
       });
     });
   });


### PR DESCRIPTION
Ensures that validation does not fail when a service declaration file other than the one being tested is malformed.
Should fix the first part of https://github.com/ambanum/OpenTermsArchive/issues/823.