### PR TITLE
Add Marketplace Buyers Conditions and Marketplace Sellers Conditions document types

### DIFF
--- a/src/archivist/services/documentTypes.json
+++ b/src/archivist/services/documentTypes.json
@@ -313,5 +313,15 @@
       "audience": "buyer",
       "object": "warranty, delivery, return of goods or services bought through a monetary transaction"
     }
+  },
+  "Marketplace Buyers Conditions": {
+    "writer": "online marketplace",
+    "audience": "buyer",
+    "object": "buying through a monetary transaction goods or services offered by sellers other than the marketplace itself"
+  },
+  "Marketplace Sellers Conditions": {
+    "writer": "online marketplace",
+    "audience": "seller",
+    "object": "selling through a monetary transaction goods or services to buyers other than the marketplace itself"
   }
 }


### PR DESCRIPTION
Closes https://github.com/ambanum/OpenTermsArchive/issues/796 and https://github.com/OpenTermsArchive/france-declarations/issues/27.

See https://github.com/ambanum/OpenTermsArchive/issues/796 for discussion on naming.

I suggest here to use “Conditions” (instead of “Policy” or “Agreement”) because this term seems to appear slightly more often in the (admittedly small) dataset looked at in https://github.com/ambanum/OpenTermsArchive/issues/796. It also happens to be the name used by legal document generators such as [Zegal](https://zegal.com/terms-and-conditions-for-online-marketplace/) and [Ironclad](https://ironcladapp.com/journal/contracts/terms-and-conditions-online-marketplace/), which I interpret as being “more common”.