### PR TITLE
Force CRLF on windows github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ${{ matrix.operating_system }}
 
     steps:
+      - run: |
+          git config --global core.autocrlf false
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
For the record, 

I installed Parallels desktop and launched linting only to realize that it was an "end of line" problem as we suspected it

This PR fixes the problem on Github actions but we still need to address the fact that windows users using the linting functionality will for sure mess then encoding on every commit.

I merge this one now to have everything deployed for the demo.

We still need to solve the above issue and I think we will need to change every declarations repo with something like a `.gitattributes` file and refreshing git like so https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings

@MattiSG not sure where to create those issues though, either 
- one in every declarations repo + template (a bit fastidious)
- one in OTA Core
- one in OTA product
please advise

