### PR TITLE
Return long hash on commit

### DIFF
--- a/src/storage-adapters/git/git.js
+++ b/src/storage-adapters/git/git.js
@@ -54,7 +54,7 @@ export default class Git {
     const shortHash = summary.commit.replace('HEAD ', '').replace('(root-commit) ', '');
     const longHash = (await this.git.show([ shortHash, '--pretty=%H', '-s' ])).trim();
 
-    return longHash; // Return a long commit hash to always handle ids in the same format and facilitate comparison as other commands return a long hash
+    return longHash; // Return a long commit hash to always handle ids in the same format and facilitate comparison
   }
 
   async pushChanges() {

--- a/src/storage-adapters/git/git.js
+++ b/src/storage-adapters/git/git.js
@@ -47,7 +47,14 @@ export default class Git {
       summary = await this.git.commit(message, options);
     }
 
-    return summary.commit.replace('HEAD ', '').replace('(root-commit) ', '');
+    if (!summary.commit) { // Nothing committed, no hash to return
+      return;
+    }
+
+    const shortHash = summary.commit.replace('HEAD ', '').replace('(root-commit) ', '');
+    const longHash = (await this.git.show([ shortHash, '--pretty=%H', '-s' ])).trim();
+
+    return longHash; // Return a long commit hash to always handle ids in the same format and facilitate comparison as other commands return a long hash
   }
 
   async pushChanges() {


### PR DESCRIPTION
Ensure to always handle ids in the same format to facilitate comparison.