### PR TITLE
Allow specifying which OTA branch to use when deploying

### DIFF
--- a/ops/inventories/dev.yml
+++ b/ops/inventories/dev.yml
@@ -8,6 +8,7 @@ all:
     declarations_directory: declarations
     app_directory: ota
     ota_repository: https://github.com/ambanum/OpenTermsArchive.git
+    ota_branch: main
   children:
     dev:
       hosts:

--- a/ops/inventories/production.yml
+++ b/ops/inventories/production.yml
@@ -8,6 +8,7 @@ all:
     declarations_directory: declarations
     app_directory: ota
     ota_repository: https://github.com/ambanum/OpenTermsArchive.git
+    ota_branch: main
   children:
     production:
       children:

--- a/ops/roles/ota/tasks/main.yml
+++ b/ops/roles/ota/tasks/main.yml
@@ -2,6 +2,7 @@
   git:
     repo: '{{ ota_repository }}'
     dest: '/home/{{ ansible_user }}/{{ app_directory }}'
+    version: '{{ ota_branch }}'
     force: yes
     accept_hostkey: yes
     key_file: '/home/{{ ansible_user }}/.ssh/ota-bot-key'


### PR DESCRIPTION
 After switching from `master` to `main` for default branch, all instances are still on `master` branch. These changes fix this.