### PR TITLE
Add custom vagrant config

### DIFF
--- a/config/vagrant.json
+++ b/config/vagrant.json
@@ -1,0 +1,5 @@
+{
+  "logger": {
+    "sendMailOnError": false
+  }
+}

--- a/ops/inventories/dev.yml
+++ b/ops/inventories/dev.yml
@@ -14,6 +14,7 @@ all:
       hosts:
         '127.0.0.1':
           ansible_ssh_port: 2222
+          config_file_name: vagrant
           ansible_python_interpreter: /usr/bin/python3
           ansible_ssh_private_key_file: ~/.ssh/ota-vagrant
           services_repository: https://github.com/OpenTermsArchive/contrib-declarations.git


### PR DESCRIPTION
When deploying on vagrant, as no `config_file_name` is specified, the `config/production.json` file is used.

Today `production.json` holds the fact that an email will be sent on error.

When `config_file_name` is set, a symbolic link to `config/local.json` is made. The `local.json` file  overrides all othe configs 
`local.json` > `production.json` > `default.json`

2 options to not receive emails when an error occurs in vagrant:

1. keep no `vagrant.json` custom file but move email config in every instance
2. create a `vagrant.json` file which disables the email sending

This PR implements the latter. 




