### PR TITLE
Improve fetcher default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ await fetch({ executeClientScripts: true, ... });
 await stopHeadlessBrowser();
 ```
 
+The `fetch` module can also be configured as a [node config submodule](https://github.com/node-config/node-config/wiki/Sub-Module-Configuration).
+If [node-config](https://github.com/node-config/node-config) is used in the project, default `fetcher` configuration can be overridden by adding a `fetcher` object to the local config. See [Configuration file](#configuration-file) for full reference.
+
 #### filter
 
 Filter gives the ability to transform HTML or pdf content into a markdown string.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ The default configuration can be found in `config/default.json`. The full refere
   },
   "fetcher": {
     "waitForElementsTimeout": "Maximum time (in milliseconds) to wait for elements to be present in the page when fetching document in a headless browser"
+    "navigationTimeout": "Maximum time (in milliseconds) to wait for page to load",
+    "language": "Language (in ISO 639-1 format) to pass in request headers"
   },
   "notifier": { // Notify specified mailing lists when new versions are recorded
     "sendInBlue": { // SendInBlue API Key is defined in environment variables, see the “Environment variables” section below

--- a/src/archivist/fetcher/exports.js
+++ b/src/archivist/fetcher/exports.js
@@ -1,4 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import config from 'config';
+
 import fetcher from './index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultConfigs = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../config/default.json')));
+
+config.util.setModuleDefaults('fetcher', defaultConfigs.fetcher);
 
 export { launchHeadlessBrowser, stopHeadlessBrowser } from './index.js';
 

--- a/src/archivist/fetcher/exports.js
+++ b/src/archivist/fetcher/exports.js
@@ -1,3 +1,5 @@
+import '../../../bin/.env.js'; // Workaround to ensure `SUPPRESS_NO_CONFIG_WARNING` is set before config is imported
+
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/src/archivist/fetcher/index.js
+++ b/src/archivist/fetcher/index.js
@@ -1,23 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import config from 'config';
+
 import fetchFullDom from './fullDomFetcher.js';
 import fetchHtmlOnly from './htmlOnlyFetcher.js';
 
 export { launchHeadlessBrowser, stopHeadlessBrowser } from './fullDomFetcher.js';
 export { FetchDocumentError } from './errors.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultConfigs = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../config/default.json')));
+
+config.util.setModuleDefaults('fetcher', defaultConfigs.fetcher);
+
 /**
  * Fetch a resource from the network, returning a promise which is fulfilled once the response is available
  *
- * @param {Object} config - Fetcher configuration
- * @param {string} config.url - URL of the resource you want to fetch
- * @param {boolean} [config.executeClientScripts] - Enable execution of client scripts. When set to `true`, this property loads the page in a headless browser to load all assets and execute client scripts before returning its content
- * @param {string|Array} [config.cssSelectors] - List of CSS selectors to await for when loading resource in a headless browser. Can be a CSS selector or an array CSS selectors. Only relevant when `executeClientScripts` is enabled
- * @param {Object} [config.options] - Fetcher options
- * @param {number} [config.options.navigationTimeout=5000] - Maximum time (in milliseconds) to wait before considering the fetch failed
- * @param {string} [config.options.language=en] - Language (in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) to be passed in request headers
- * @param {number} [config.options.waitForElementsTimeout=5000] - Maximum time (in milliseconds) to wait for selectors to exist on page before considering the fetch failed. Only relevant when `executeClientScripts` is enabled
+ * @param {Object} params - Fetcher parameters
+ * @param {string} params.url - URL of the resource you want to fetch
+ * @param {boolean} [params.executeClientScripts] - Enable execution of client scripts. When set to `true`, this property loads the page in a headless browser to load all assets and execute client scripts before returning its content
+ * @param {string|Array} [params.cssSelectors] - List of CSS selectors to await for when loading resource in a headless browser. Can be a CSS selector or an array CSS selectors. Only relevant when `executeClientScripts` is enabled
+ * @param {Object} [params.config] - Fetcher configuration
+ * @param {number} [params.config.navigationTimeout] - Maximum time (in milliseconds) to wait before considering the fetch failed
+ * @param {string} [params.config.language] - Language (in [ISO 639-1 format](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) to be passed in request headers
+ * @param {number} [params.config.waitForElementsTimeout] - Maximum time (in milliseconds) to wait for selectors to exist on page before considering the fetch failed. Only relevant when `executeClientScripts` is enabled
  * @returns {Promise} @returns {Promise<Object>} Promise which will be resolved with an object containing the `mimeType` and the `content` of the url as string or buffer
  */
-export default async function fetch({ url, executeClientScripts, cssSelectors, options: { navigationTimeout = 5000, language = 'en', waitForElementsTimeout = 5000 } = {} }) {
+export default async function fetch({
+  url, executeClientScripts, cssSelectors,
+  config: {
+    navigationTimeout = config.get('fetcher.navigationTimeout'),
+    language = config.get('fetcher.language'),
+    waitForElementsTimeout = config.get('fetcher.waitForElementsTimeout'),
+  } = {},
+}) {
   if (executeClientScripts) {
     return fetchFullDom(url, cssSelectors, { navigationTimeout, language, waitForElementsTimeout });
   }

--- a/src/archivist/fetcher/index.js
+++ b/src/archivist/fetcher/index.js
@@ -1,7 +1,3 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import config from 'config';
 
 import fetchFullDom from './fullDomFetcher.js';
@@ -9,11 +5,6 @@ import fetchHtmlOnly from './htmlOnlyFetcher.js';
 
 export { launchHeadlessBrowser, stopHeadlessBrowser } from './fullDomFetcher.js';
 export { FetchDocumentError } from './errors.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const defaultConfigs = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../../config/default.json')));
-
-config.util.setModuleDefaults('fetcher', defaultConfigs.fetcher);
 
 /**
  * Fetch a resource from the network, returning a promise which is fulfilled once the response is available

--- a/src/archivist/fetcher/index.test.js
+++ b/src/archivist/fetcher/index.test.js
@@ -5,9 +5,8 @@ import { fileURLToPath } from 'url';
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import config from 'config';
 
-import fetchWithoutConfig, { launchHeadlessBrowser, stopHeadlessBrowser, FetchDocumentError } from './index.js';
+import fetch, { launchHeadlessBrowser, stopHeadlessBrowser, FetchDocumentError } from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,8 +16,6 @@ const SERVER_PORT = 8976;
 chai.use(chaiAsPromised);
 
 const termsHTML = '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>First provider TOS</title></head><body><h1>Terms of service</h1><p>Dapibus quis diam sagittis</p></body></html>';
-
-const fetch = args => fetchWithoutConfig({ options: config.get('fetcher'), ...args });
 
 describe('Fetcher', function () {
   this.timeout(10000);


### PR DESCRIPTION
It allows to define default configuration values at only one place. It also allows users who import the `fetcher` module and which already use `node-config` to override the default values for the `fetcher` module in their already existing config files.

It also make me think that we should wrap all our configuration inside a `open-terms-archive` key to avoid conflict with such a generic terms as `fetcher`.
