### PR TITLE
Update simple-git to 3.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@accordproject/markdown-cicero": "^0.15.2",
         "@accordproject/markdown-pdf": "^0.15.2",
-        "@opentermsarchive/simple-git": "^3.7.2",
         "abort-controller": "^3.0.0",
         "ajv": "^6.12.6",
         "archiver": "^5.3.0",
@@ -47,6 +46,7 @@
         "puppeteer-extra": "^3.2.3",
         "puppeteer-extra-plugin-stealth": "^2.9.0",
         "sib-api-v3-sdk": "^8.2.1",
+        "simple-git": "^3.8.0",
         "turndown": "^7.0.0",
         "winston": "^3.3.3",
         "winston-mail": "^2.0.0"
@@ -789,36 +789,6 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.12.0.tgz",
       "integrity": "sha512-G0k7CoS9bK+OI7kPHgqi1KqK4WhrjDQSjy0wJI+0OTx/xvbHUIZDeqatY60ceeRINP/1ExEk6kTARboP0xavEw=="
-    },
-    "node_modules/@opentermsarchive/simple-git": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@opentermsarchive/simple-git/-/simple-git-3.7.2.tgz",
-      "integrity": "sha512-H47Io1nMzkehYMD2ZKyoHcG/cH1zoFzCtw77aAi9qWELa4RnziSdQsO7JYmvFNJKyUXwyyenGaEtaJe0D2LVqA==",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/steveukx/"
-      }
-    },
-    "node_modules/@opentermsarchive/simple-git/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6689,6 +6659,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-git": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.8.0.tgz",
+      "integrity": "sha512-nbR1PufcbvCaW90CiAXC1mM7OnEqLzjSOnySnq7Sd2kcVG6GxSa+DhxhFmCgxLv4kWCKmZagkCZSjfNAQTZwaw==",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/steveukx/"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -8240,26 +8240,6 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.12.0.tgz",
       "integrity": "sha512-G0k7CoS9bK+OI7kPHgqi1KqK4WhrjDQSjy0wJI+0OTx/xvbHUIZDeqatY60ceeRINP/1ExEk6kTARboP0xavEw=="
-    },
-    "@opentermsarchive/simple-git": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@opentermsarchive/simple-git/-/simple-git-3.7.2.tgz",
-      "integrity": "sha512-H47Io1nMzkehYMD2ZKyoHcG/cH1zoFzCtw77aAi9qWELa4RnziSdQsO7JYmvFNJKyUXwyyenGaEtaJe0D2LVqA==",
-      "requires": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -12645,6 +12625,26 @@
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
           "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        }
+      }
+    },
+    "simple-git": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.8.0.tgz",
+      "integrity": "sha512-nbR1PufcbvCaW90CiAXC1mM7OnEqLzjSOnySnq7Sd2kcVG6GxSa+DhxhFmCgxLv4kWCKmZagkCZSjfNAQTZwaw==",
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@accordproject/markdown-cicero": "^0.15.2",
     "@accordproject/markdown-pdf": "^0.15.2",
-    "@opentermsarchive/simple-git": "^3.7.2",
     "abort-controller": "^3.0.0",
     "ajv": "^6.12.6",
     "archiver": "^5.3.0",
@@ -73,6 +72,7 @@
     "puppeteer-extra": "^3.2.3",
     "puppeteer-extra-plugin-stealth": "^2.9.0",
     "sib-api-v3-sdk": "^8.2.1",
+    "simple-git": "^3.8.0",
     "turndown": "^7.0.0",
     "winston": "^3.3.3",
     "winston-mail": "^2.0.0"

--- a/src/archivist/recorder/repositories/git/git.js
+++ b/src/archivist/recorder/repositories/git/git.js
@@ -1,7 +1,7 @@
 import fsApi from 'fs';
 import path from 'path';
 
-import simpleGit from '@opentermsarchive/simple-git';
+import simpleGit from 'simple-git';
 
 process.env.LC_ALL = 'en_GB'; // Ensure git messages will be in English as some errors are handled by analysing the message content
 


### PR DESCRIPTION
Switch back from our fork to the original simple-git lib as [since 3.8.0](https://github.com/steveukx/git-js/pull/797) it supports `--name-only` log formats in `diffSummary`