### PR TITLE
Suggest a more universal install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For example:
 Open Terms Archive exposes a JavaScript API to make some of its capabilities available in NodeJS. You can install it as an NPM module: 
 
 ```
-npm install ambanum/OpenTermsArchive#main
+npm install "ambanum/OpenTermsArchive#main"
 ```
 
 ### CLI


### PR DESCRIPTION
The `#` has a [specific meaning](https://stackoverflow.com/questions/12303805/oh-my-zsh-hash-pound-symbol-bad-pattern-or-match-not-found#13783754) with `zsh`.

The `"` add some complexity and allow the command to be directly used in more contexts.