### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Start MongoDB (Windows)
         if: runner.os == 'Windows'
         run: |
-          Set-Service MongoDB -StartupType Automatic          
-          Start-Service -Name MongoDB
+          sc.exe config MongoDB start= auto
+          sc.exe start MongoDB
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,6 @@ jobs:
 
     runs-on: ${{ matrix.operating_system }}
 
-    services:
-      mongo:
-        image: mongo
-        ports:
-          - 27017:27017
-
     steps:
       - run: |
           git config --global user.name 'Open Terms Archive Bot'
@@ -32,6 +26,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+      - name: Start MongoDB
+        run: |
+          mkdir /tmp/test-database
+          mongod --dbpath /tmp/test-database --fork --logpath /tmp/mongodb-log
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
 
     runs-on: ${{ matrix.operating_system }}
 
+    env:
+      MONGODB_VERSION: 4.4
+
     steps:
       - run: |
           git config --global user.name 'Open Terms Archive Bot'
@@ -30,12 +33,12 @@ jobs:
         if: matrix.operating_system == 'ubuntu-latest'
         uses: supercharge/mongodb-github-action@1.7.0
         with:
-          mongodb-version: 4.4
+          mongodb-version: ${{ env.MONGODB_VERSION }}
       - name: Install and Start MongoDB (windows)
         if: matrix.operating_system == 'windows-2019'
         uses: crazy-max/ghaction-chocolatey@v2
         with:
-          args: install mongodb
+          args: install mongodb --force --version=${{ env.MONGODB_VERSION }}
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           mongodb-version: 4.4
       - name: Install and Start MongoDB (windows)
         if: matrix.operating_system == 'windows-2019'
-        uses: crazy-max/ghaction-chocolatey@v1.6.0
+        uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install mongodb
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
 
     runs-on: ${{ matrix.operating_system }}
 
-    env:
-      MONGODB_VERSION: 4.4
-
     steps:
       - run: |
           git config --global user.name 'Open Terms Archive Bot'
@@ -29,16 +26,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-      - name: Install and Start MongoDB (ubuntu)
-        if: matrix.operating_system == 'ubuntu-latest'
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: ${{ env.MONGODB_VERSION }}
-      - name: Install and Start MongoDB (windows)
-        if: matrix.operating_system == 'windows-2019'
-        uses: crazy-max/ghaction-chocolatey@v2
-        with:
-          args: install mongodb --force --version=${{ env.MONGODB_VERSION }}
+      - name: Start MongoDB
+        run: |
+          mkdir /tmp/test-database
+          mongod --dbpath /tmp/test-database --fork --logpath /tmp/mongodb-log
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Start MongoDB (Windows)
         if: runner.os == 'Windows'
         run: |
-          sc.exe config MongoDB start= auto
-          sc.exe start MongoDB
+          Set-Service MongoDB -StartupType Automatic          
+          Start-Service -Name MongoDB
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,12 @@ jobs:
 
     runs-on: ${{ matrix.operating_system }}
 
+    services:
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+
     steps:
       - run: |
           git config --global user.name 'Open Terms Archive Bot'
@@ -26,10 +32,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-      - name: Start MongoDB
-        run: |
-          mkdir /tmp/test-database
-          mongod --dbpath /tmp/test-database --fork --logpath /tmp/mongodb-log
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,19 @@ jobs:
           git config --global user.email 'bot@opentermsarchive.org'
           git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - name: Start MongoDB
+      - name: Start MongoDB (UNIX)
+        if: runner.os != 'Windows'
         run: |
           mkdir /tmp/test-database
           mongod --dbpath /tmp/test-database --fork --logpath /tmp/mongodb-log
+      - name: Start MongoDB (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Set-Service MongoDB -StartupType Automatic          
+          Start-Service -Name MongoDB
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        operating_system: [ ubuntu-latest, windows-2019 ]
+        operating_system: [ ubuntu-latest, windows-latest ]
       fail-fast: false # run tests on other operating systems even if one fails
 
     runs-on: ${{ matrix.operating_system }}
@@ -36,7 +36,7 @@ jobs:
   validate_declarations:
     strategy:
       matrix:
-        operating_system: [ubuntu-latest, windows-2019]
+        operating_system: [ ubuntu-latest, windows-latest ]
       fail-fast: false # run tests on other operating systems even if one fails
 
     runs-on: ${{ matrix.operating_system }}


### PR DESCRIPTION
**Since early August, tests fail for Windows in CI. This changeset implements the GitHub Actions recommended solution. However, tests (https://github.com/actions/runner-images/issues/5949#issuecomment-1223986695) show that this solution is flaky, and we might have to re-run tests when they fail.** The observed frequency of failure is about ¼. This is still a significant improvement over the current 100% failure rate. Read below for an in-depth explanation of the root cause.

This changeset also **unifies both Linux and Windows steps to use the default, pre-installed version of MongoDB v5** on the GitHub Actions runners. This means faster tests in CI for Linux, decreased resources consumption, and unifying the MongoDB versions: until now, we were specifying v4 for Linux and relying on the pre-installed v5 for Windows. Unfortunately, the tests are not faster for Windows, as starting the MongoDB service is long (https://github.com/actions/runner-images/issues/5949#issuecomment-1224200510).

Finally, this changeset **updates the Windows runners from Windows Server 2019 to Windows Server 2022**, removes dependencies on third-party actions, and brings MongoDB logs on Linux runs.

### Root cause analysis

After investigation, this seems to be a consequence of https://github.com/actions/runner-images/issues/5949, where GitHub Actions changed the default status of a MongoDB service that is preinstalled on their Windows runners from “started” to “stopped”. We used to install MongoDB through `chocolatey`, a package manager for Windows, however it seems this never did anything beyond wasting resources, since the package was already preinstalled (https://github.com/actions/runner-images/issues/20) and started. This change from GitHub revealed that we never actually started the service.

### Implementation choices

The most elegant solution to use MongoDB would be to use the `services` instruction, as illustrated in 50d8a243bb1c08c43ffc1fe9c4ef0c385009216f.

However, Docker is not supported on Windows runners (https://github.com/actions/runner/issues/904). We thus cannot use the `services` instruction, which otherwise is very useful to declaratively start a service.

The alternative would be to start `mongod` in a dedicated `step`. However, this has to be done in the background, otherwise the step is blocking. Unfortunately, the [`--fork` option is not supported on Windows](https://www.mongodb.com/docs/manual/reference/program/mongod/#std-option-mongod.--fork) and using `&`, while [supported in PowerShell](https://stackoverflow.com/questions/185575/powershell-equivalent-of-bash-ampersand-for-forking-running-background-proce), [does not seem](https://github.com/ambanum/OpenTermsArchive/actions/runs/2889002081) to start the server on GitHub Actions.

This is all detailed in https://github.com/orgs/community/discussions/30083.

I decided to keep the different major tracks followed in the Git history, so alternatives that were explored can be retrieved.

### Long-term solution

I recommend discussing the relevance of dropping MongoDB tests on platforms other than Linux. This would speed up the pipeline significantly, and I believe the cost is acceptable: MongoDB is an optimisation for large-scale libraries. Those are most likely to be run on Linux, and considering our available resources, it sounds fair to me that we don't invest in testing this specific setup cross-platform.