### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
 
     steps:
       - run: |
-          git config --global user.name 'Open Terms Archive Bot'
-          git config --global user.email 'bot@opentermsarchive.org'
           git config --global core.autocrlf false
       - uses: actions/checkout@v2
       - name: Start MongoDB (UNIX)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches-ignore:
-      - main # tests will be launched by workflow_call push:
+      - main # tests will be launched by workflow_call from the deploy workflow
   pull_request:
     types: [ opened, reopened ]
   workflow_call:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm test
+      - name: Archive database logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: mongodb-log
+          path: $RUNNER_TEMP/mongodb-log
 
   validate_declarations:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        operating_system: [ ubuntu-latest, windows-latest ]
+        operating_system: [ ubuntu-latest, windows-latest, macos-latest ]
       fail-fast: false # run tests on other operating systems even if one fails
 
     runs-on: ${{ matrix.operating_system }}
@@ -24,8 +24,8 @@ jobs:
       - name: Start MongoDB (UNIX)
         if: runner.os != 'Windows'
         run: |
-          mkdir /tmp/test-database
-          mongod --dbpath /tmp/test-database --fork --logpath /tmp/mongodb-log
+          mkdir $RUNNER_TEMP/test-database
+          mongod --dbpath $RUNNER_TEMP/test-database --fork --logpath $RUNNER_TEMP/mongodb-log
       - name: Start MongoDB (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -40,7 +40,7 @@ jobs:
   validate_declarations:
     strategy:
       matrix:
-        operating_system: [ ubuntu-latest, windows-latest ]
+        operating_system: [ ubuntu-latest, windows-latest, macos-latest ]
       fail-fast: false # run tests on other operating systems even if one fails
 
     runs-on: ${{ matrix.operating_system }}

--- a/config/default.json
+++ b/config/default.json
@@ -29,7 +29,7 @@
           }
         },
         "mongo": {
-          "connectionURI": "mongodb://localhost:27017",
+          "connectionURI": "mongodb://127.0.0.1:27017",
           "database": "open-terms-archive",
           "collection": "snapshots"
         }

--- a/config/test.json
+++ b/config/test.json
@@ -15,7 +15,7 @@
           }
         },
         "mongo": {
-          "connectionURI": "mongodb://localhost:27017",
+          "connectionURI": "mongodb://127.0.0.1:27017",
           "database": "open-terms-archive-test",
           "collection": "versions"
         }
@@ -32,7 +32,7 @@
           }
         },
         "mongo": {
-          "connectionURI": "mongodb://localhost:27017",
+          "connectionURI": "mongodb://127.0.0.1:27017",
           "database": "open-terms-archive-test",
           "collection": "snapshots"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "lodash": "^4.17.21",
         "mime": "^2.5.2",
         "mocha": "^9.1.3",
-        "mongodb": "^4.2.0",
+        "mongodb": "^4.9.0",
         "node-fetch": "^3.1.0",
         "octokit": "^1.7.0",
         "pdfjs-dist": "^2.9.359",
@@ -915,9 +915,9 @@
       "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
-      "integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -4092,6 +4092,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5309,13 +5314,14 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.2.1.tgz",
-      "integrity": "sha512-nDC+ulM/Ea3Q2VG5eemuGfB7T4ORwrtKegH2XW9OLlUBgQF6OTNrzFCS1Z3SJGVA+T0Sr1xBYV6DMnp0A7us0g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.0.tgz",
+      "integrity": "sha512-tJJEFJz7OQTQPZeVHZJIeSOjMRqc5eSyXTt86vSQENEErpkiG7279tM/GT5AVZ7TgXNh9HQxoa2ZkbrANz5GQw==",
       "dependencies": {
-        "bson": "^4.6.0",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.2.0"
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "socks": "^2.7.0"
       },
       "engines": {
         "node": ">=12.9.0"
@@ -5325,9 +5331,9 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
-      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -6732,6 +6738,28 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/sort-object-keys": {
@@ -8355,9 +8383,9 @@
       "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
     "@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "requires": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -8954,9 +8982,9 @@
       }
     },
     "bson": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
-      "integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -9520,9 +9548,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "denque": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -10750,6 +10778,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -11652,20 +11685,21 @@
       }
     },
     "mongodb": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.2.1.tgz",
-      "integrity": "sha512-nDC+ulM/Ea3Q2VG5eemuGfB7T4ORwrtKegH2XW9OLlUBgQF6OTNrzFCS1Z3SJGVA+T0Sr1xBYV6DMnp0A7us0g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.0.tgz",
+      "integrity": "sha512-tJJEFJz7OQTQPZeVHZJIeSOjMRqc5eSyXTt86vSQENEErpkiG7279tM/GT5AVZ7TgXNh9HQxoa2ZkbrANz5GQw==",
       "requires": {
-        "bson": "^4.6.0",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.2.0",
-        "saslprep": "^1.0.3"
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.0"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
-      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -12698,6 +12732,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
     },
     "sort-object-keys": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lodash": "^4.17.21",
     "mime": "^2.5.2",
     "mocha": "^9.1.3",
-    "mongodb": "^4.2.0",
+    "mongodb": "^4.9.0",
     "node-fetch": "^3.1.0",
     "octokit": "^1.7.0",
     "pdfjs-dist": "^2.9.359",

--- a/scripts/import/config/import.json
+++ b/scripts/import/config/import.json
@@ -3,7 +3,7 @@
     "sourcePath": "../ota-snapshots",
     "githubRepository": "ambanum/OpenTermsArchive-snapshots",
     "mongo": {
-      "connectionURI": "mongodb://localhost:27017",
+      "connectionURI": "mongodb://127.0.0.1:27017",
       "database": "open-terms-archive-import-retry",
       "snapshotsCollection": "snapshots",
       "commitsCollection": "commits"

--- a/src/archivist/fetcher/index.test.js
+++ b/src/archivist/fetcher/index.test.js
@@ -58,7 +58,7 @@ describe('Fetcher', function () {
       context('when html page is available', () => {
         let content;
         let mimeType;
-        const url = `http://localhost:${SERVER_PORT}`;
+        const url = `http://127.0.0.1:${SERVER_PORT}`;
 
         context('when expected selectors are present', () => {
           before(async () => {
@@ -122,7 +122,7 @@ describe('Fetcher', function () {
       context('when url targets a PDF file', () => {
         let content;
         let mimeType;
-        const pdfUrl = `http://localhost:${SERVER_PORT}/terms.pdf`;
+        const pdfUrl = `http://127.0.0.1:${SERVER_PORT}/terms.pdf`;
 
         before(async () => {
           ({ content, mimeType } = await fetch({ url: pdfUrl }));
@@ -143,7 +143,7 @@ describe('Fetcher', function () {
     });
 
     describe('Error handling', () => {
-      const url404 = `http://localhost:${SERVER_PORT}/404`;
+      const url404 = `http://127.0.0.1:${SERVER_PORT}/404`;
 
       context('when web page is not available', () => {
         it('throws a FetchDocumentError error', async () => {

--- a/src/archivist/recorder/index.test.js
+++ b/src/archivist/recorder/index.test.js
@@ -15,24 +15,26 @@ describe('Recorder', () => {
 
   for (const repositoryType of [ 'git', 'mongo' ]) {
     describe(repositoryType, () => {
+      let recorder;
+
+      before(async () => {
+        const options = config.util.cloneDeep(config.recorder);
+
+        options.versions.storage.type = repositoryType;
+        options.snapshots.storage.type = repositoryType;
+
+        recorder = new Recorder(options);
+        await recorder.initialize();
+      });
+
+      after(async () => recorder.finalize());
+
       describe('#recordSnapshot', () => {
         const CONTENT = '<html><h1>ToS fixture data with UTF-8 çhãràčtęrs</h1></html>';
-        let recorder;
+
         let id;
         let isFirstRecord;
         let record;
-
-        before(async () => {
-          const options = config.util.cloneDeep(config.recorder);
-
-          options.versions.storage.type = repositoryType;
-          options.snapshots.storage.type = repositoryType;
-
-          recorder = new Recorder(options);
-          await recorder.initialize();
-        });
-
-        after(async () => recorder.finalize());
 
         context('when a required param is missing', () => {
           after(async () => recorder.snapshotsRepository.removeAll());
@@ -170,17 +172,10 @@ describe('Recorder', () => {
       describe('#recordVersion', () => {
         const CONTENT = '# ToS fixture data with UTF-8 çhãràčtęrs';
         const SNAPSHOT_ID = '61af86dc5ff5caa74ae926ad';
-        let recorder;
+
         let id;
         let isFirstRecord;
         let record;
-
-        before(async () => {
-          recorder = new Recorder(config.get('recorder'));
-          await recorder.initialize();
-        });
-
-        after(async () => recorder.finalize());
 
         context('when a required param is missing', () => {
           after(async () => recorder.versionsRepository.removeAll());
@@ -322,17 +317,10 @@ describe('Recorder', () => {
       describe('#recordRefilter', () => {
         const CONTENT = '# ToS fixture data with UTF-8 çhãràčtęrs';
         const SNAPSHOT_ID = '61af86dc5ff5caa74ae926ad';
-        let recorder;
+
         let id;
         let isFirstRecord;
         let record;
-
-        before(async () => {
-          recorder = new Recorder(config.get('recorder'));
-          await recorder.initialize();
-        });
-
-        after(async () => recorder.finalize());
 
         context('when a required param is missing', () => {
           after(async () => recorder.versionsRepository.removeAll());

--- a/src/archivist/recorder/repositories/mongo/index.js
+++ b/src/archivist/recorder/repositories/mongo/index.js
@@ -12,11 +12,10 @@ import * as DataMapper from './dataMapper.js';
 export default class MongoRepository extends RepositoryInterface {
   constructor({ database: databaseName, collection: collectionName, connectionURI }) {
     super();
-    const client = new MongoClient(connectionURI);
 
+    this.client = new MongoClient(connectionURI);
     this.databaseName = databaseName;
     this.collectionName = collectionName;
-    this.client = client;
   }
 
   async initialize() {


### PR DESCRIPTION
Following exploration of the problem (hopefully) fixed by #904, I found several inconsistencies or venues for improvement in our current CI setup. This changeset collects them and:

- Adds logs for MongoDB server on CI.
- Adds macOS testing in CI.
- Enables testing MongoDB on IPv6-enabled hosts. On my machine, for example, my hosts file maps `localhost` to the IPv6 `::1` loopback interface instead of only the IPv4, and that seems to prevent the Mongo client from connecting to the database.
- Actually tests all `Recorder` operations on MongoDB. The initialisation step was not factored properly and we ended up testing version recording and refiltering twice with Git, not with MongoDB.
- Updates the `mongodb` driver version to bring compatibility with MongoDB v6, which came out late July.
- Removes obsolete `git config --global` for user name and email in CI.