### PR TITLE
Fix range selectors puppeteer

### DIFF
--- a/src/archivist/fetcher/index.js
+++ b/src/archivist/fetcher/index.js
@@ -1,5 +1,7 @@
 import config from 'config';
 
+import DocumentDeclaration from '../services/documentDeclaration.js';
+
 import fetchFullDom from './fullDomFetcher.js';
 import fetchHtmlOnly from './htmlOnlyFetcher.js';
 
@@ -20,7 +22,9 @@ export { FetchDocumentError } from './errors.js';
  * @returns {Promise} @returns {Promise<Object>} Promise which will be resolved with an object containing the `mimeType` and the `content` of the URL as string or Buffer
  */
 export default async function fetch({
-  url, executeClientScripts, cssSelectors,
+  url,
+  executeClientScripts,
+  cssSelectors,
   config: {
     navigationTimeout = config.get('fetcher.navigationTimeout'),
     language = config.get('fetcher.language'),
@@ -28,7 +32,7 @@ export default async function fetch({
   } = {},
 }) {
   if (executeClientScripts) {
-    return fetchFullDom(url, cssSelectors, { navigationTimeout, language, waitForElementsTimeout });
+    return fetchFullDom(url, DocumentDeclaration.extractCssSelectorsFromProperty(cssSelectors), { navigationTimeout, language, waitForElementsTimeout });
   }
 
   return fetchHtmlOnly(url, { navigationTimeout, language });

--- a/src/archivist/fetcher/index.test.js
+++ b/src/archivist/fetcher/index.test.js
@@ -62,7 +62,7 @@ describe('Fetcher', function () {
 
         context('when expected selectors are present', () => {
           before(async () => {
-            ({ content, mimeType } = await fetch({ url, selectors: 'body' }));
+            ({ content, mimeType } = await fetch({ url, cssSelectors: 'body' }));
           });
 
           it('returns the web page content of the given URL', async () => {
@@ -75,7 +75,7 @@ describe('Fetcher', function () {
 
           context('with client script enabled', () => {
             before(async () => {
-              ({ content, mimeType } = await fetch({ url, selectors: 'body', executeClientScripts: true }));
+              ({ content, mimeType } = await fetch({ url, cssSelectors: 'body', executeClientScripts: true }));
             });
 
             it('returns the web page content of the given URL', async () => {
@@ -92,7 +92,7 @@ describe('Fetcher', function () {
           const NOT_PRESENT_SELECTOR = 'h2';
 
           before(async () => {
-            ({ content, mimeType } = await fetch({ url, selectors: NOT_PRESENT_SELECTOR }));
+            ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_SELECTOR }));
           });
 
           it('returns the web page content of the given URL', async () => {
@@ -105,7 +105,7 @@ describe('Fetcher', function () {
 
           context('with client script enabled', () => {
             before(async () => {
-              ({ content, mimeType } = await fetch({ url, selectors: NOT_PRESENT_SELECTOR, executeClientScripts: true }));
+              ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_SELECTOR, executeClientScripts: true }));
             });
 
             it('returns the web page content of the given URL', async () => {

--- a/src/archivist/fetcher/index.test.js
+++ b/src/archivist/fetcher/index.test.js
@@ -88,6 +88,36 @@ describe('Fetcher', function () {
           });
         });
 
+        context('when expected range selectors are present', () => {
+          const PRESENT_RANGE_SELECTOR = { startBefore: 'p', endBefore: 'body' };
+
+          before(async () => {
+            ({ content, mimeType } = await fetch({ url, cssSelectors: PRESENT_RANGE_SELECTOR }));
+          });
+
+          it('returns the web page content of the given URL', async () => {
+            expect(content).to.equal(termsHTML);
+          });
+
+          it('returns the MIME type of the given URL', async () => {
+            expect(mimeType).to.equal('text/html');
+          });
+
+          context('with client script enabled', () => {
+            before(async () => {
+              ({ content, mimeType } = await fetch({ url, cssSelectors: PRESENT_RANGE_SELECTOR, executeClientScripts: true }));
+            });
+
+            it('returns the web page content of the given URL', async () => {
+              expect(content).to.equal(termsHTML);
+            });
+
+            it('returns the MIME type of the given URL', async () => {
+              expect(mimeType).to.equal('text/html');
+            });
+          });
+        });
+
         context('when expected selectors are not present', () => {
           const NOT_PRESENT_SELECTOR = 'h2';
 
@@ -106,6 +136,36 @@ describe('Fetcher', function () {
           context('with client script enabled', () => {
             before(async () => {
               ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_SELECTOR, executeClientScripts: true }));
+            });
+
+            it('returns the web page content of the given URL', async () => {
+              expect(content).to.equal(termsHTML);
+            });
+
+            it('returns the MIME type of the given URL', async () => {
+              expect(mimeType).to.equal('text/html');
+            });
+          });
+        });
+
+        context('when expected range selectors are not present', () => {
+          const NOT_PRESENT_RANGE_SELECTOR = { startBefore: 'h2', endBefore: 'body' };
+
+          before(async () => {
+            ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_RANGE_SELECTOR }));
+          });
+
+          it('returns the web page content of the given URL', async () => {
+            expect(content).to.equal(termsHTML);
+          });
+
+          it('returns the MIME type of the given URL', async () => {
+            expect(mimeType).to.equal('text/html');
+          });
+
+          context('with client script enabled', () => {
+            before(async () => {
+              ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_RANGE_SELECTOR, executeClientScripts: true }));
             });
 
             it('returns the web page content of the given URL', async () => {

--- a/src/archivist/fetcher/index.test.js
+++ b/src/archivist/fetcher/index.test.js
@@ -60,22 +60,18 @@ describe('Fetcher', function () {
         let mimeType;
         const url = `http://127.0.0.1:${SERVER_PORT}`;
 
-        context('when expected selectors are present', () => {
-          before(async () => {
-            ({ content, mimeType } = await fetch({ url, cssSelectors: 'body' }));
-          });
+        const EXISTING_SELECTORS = {
+          String: 'body',
+          'Array of strings': [ 'body', 'p' ],
+          Range: { startBefore: 'p', endBefore: 'body' },
+          'Array of ranges': [{ startBefore: 'p', endBefore: 'body' }],
+          Mixed: [{ startBefore: 'h1', endBefore: 'body' }, 'p' ],
+        };
 
-          it('returns the web page content of the given URL', async () => {
-            expect(content).to.equal(termsHTML);
-          });
-
-          it('returns the MIME type of the given URL', async () => {
-            expect(mimeType).to.equal('text/html');
-          });
-
-          context('with client script enabled', () => {
+        Object.entries(EXISTING_SELECTORS).forEach(([ name, existingSelectors ]) => {
+          context(`when ${name} selectors are present`, () => {
             before(async () => {
-              ({ content, mimeType } = await fetch({ url, cssSelectors: 'body', executeClientScripts: true }));
+              ({ content, mimeType } = await fetch({ url, cssSelectors: existingSelectors }));
             });
 
             it('returns the web page content of the given URL', async () => {
@@ -84,28 +80,36 @@ describe('Fetcher', function () {
 
             it('returns the MIME type of the given URL', async () => {
               expect(mimeType).to.equal('text/html');
+            });
+
+            context('with client script enabled', () => {
+              before(async () => {
+                ({ content, mimeType } = await fetch({ url, cssSelectors: existingSelectors, executeClientScripts: true }));
+              });
+
+              it('returns the web page content of the given URL', async () => {
+                expect(content).to.equal(termsHTML);
+              });
+
+              it('returns the MIME type of the given URL', async () => {
+                expect(mimeType).to.equal('text/html');
+              });
             });
           });
         });
 
-        context('when expected range selectors are present', () => {
-          const PRESENT_RANGE_SELECTOR = { startBefore: 'p', endBefore: 'body' };
+        const ABSENT_SELECTORS = {
+          String: 'h2',
+          'Array of strings': [ 'h2', 'p' ],
+          Range: { startBefore: 'h2', endBefore: 'body' },
+          'Array of ranges': [{ startBefore: 'h2', endBefore: 'body' }],
+          Mixed: [{ startBefore: 'h2', endBefore: 'body' }, 'p' ],
+        };
 
-          before(async () => {
-            ({ content, mimeType } = await fetch({ url, cssSelectors: PRESENT_RANGE_SELECTOR }));
-          });
-
-          it('returns the web page content of the given URL', async () => {
-            expect(content).to.equal(termsHTML);
-          });
-
-          it('returns the MIME type of the given URL', async () => {
-            expect(mimeType).to.equal('text/html');
-          });
-
-          context('with client script enabled', () => {
+        Object.entries(ABSENT_SELECTORS).forEach(([ name, absentSelectors ]) => {
+          context(`when ${name} selectors are not existing in the page`, () => {
             before(async () => {
-              ({ content, mimeType } = await fetch({ url, cssSelectors: PRESENT_RANGE_SELECTOR, executeClientScripts: true }));
+              ({ content, mimeType } = await fetch({ url, cssSelectors: absentSelectors }));
             });
 
             it('returns the web page content of the given URL', async () => {
@@ -115,65 +119,19 @@ describe('Fetcher', function () {
             it('returns the MIME type of the given URL', async () => {
               expect(mimeType).to.equal('text/html');
             });
-          });
-        });
 
-        context('when expected selectors are not present', () => {
-          const NOT_PRESENT_SELECTOR = 'h2';
+            context('with client script enabled', () => {
+              before(async () => {
+                ({ content, mimeType } = await fetch({ url, cssSelectors: absentSelectors, executeClientScripts: true }));
+              });
 
-          before(async () => {
-            ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_SELECTOR }));
-          });
+              it('returns the web page content of the given URL', async () => {
+                expect(content).to.equal(termsHTML);
+              });
 
-          it('returns the web page content of the given URL', async () => {
-            expect(content).to.equal(termsHTML);
-          });
-
-          it('returns the MIME type of the given URL', async () => {
-            expect(mimeType).to.equal('text/html');
-          });
-
-          context('with client script enabled', () => {
-            before(async () => {
-              ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_SELECTOR, executeClientScripts: true }));
-            });
-
-            it('returns the web page content of the given URL', async () => {
-              expect(content).to.equal(termsHTML);
-            });
-
-            it('returns the MIME type of the given URL', async () => {
-              expect(mimeType).to.equal('text/html');
-            });
-          });
-        });
-
-        context('when expected range selectors are not present', () => {
-          const NOT_PRESENT_RANGE_SELECTOR = { startBefore: 'h2', endBefore: 'body' };
-
-          before(async () => {
-            ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_RANGE_SELECTOR }));
-          });
-
-          it('returns the web page content of the given URL', async () => {
-            expect(content).to.equal(termsHTML);
-          });
-
-          it('returns the MIME type of the given URL', async () => {
-            expect(mimeType).to.equal('text/html');
-          });
-
-          context('with client script enabled', () => {
-            before(async () => {
-              ({ content, mimeType } = await fetch({ url, cssSelectors: NOT_PRESENT_RANGE_SELECTOR, executeClientScripts: true }));
-            });
-
-            it('returns the web page content of the given URL', async () => {
-              expect(content).to.equal(termsHTML);
-            });
-
-            it('returns the MIME type of the given URL', async () => {
-              expect(mimeType).to.equal('text/html');
+              it('returns the MIME type of the given URL', async () => {
+                expect(mimeType).to.equal('text/html');
+              });
             });
           });
         });


### PR DESCRIPTION
This closes #906

I decided to keep the logic of css selectors flattening in the fetcher itself as if not, the contribution tool would also need to be updated.
Also I think we must have an open discussion about the coherence between a DocumentDeclaration and the representation of this declaration in the JSON file. 
From what I see, we could benefit a lot about making them converge.

This PR is blocking for adding Airbnb documents on P2B.
