### PR TITLE
Use third-party action to set up MongoDB in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,26 +21,14 @@ jobs:
       - run: |
           git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - name: Start MongoDB (UNIX)
-        if: runner.os != 'Windows'
-        run: |
-          mkdir $RUNNER_TEMP/test-database
-          mongod --dbpath $RUNNER_TEMP/test-database --fork --logpath $RUNNER_TEMP/mongodb-log
-      - name: Start MongoDB (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Set-Service MongoDB -StartupType Automatic          
-          Start-Service -Name MongoDB
+      - uses: ankane/setup-mongodb@v1
+        with:
+          mongodb-version: 5.0
       - uses: actions/setup-node@v2
         with:
           node-version: 16
       - run: npm ci
       - run: npm test
-      - name: Archive database logs
-        uses: actions/upload-artifact@v3
-        with:
-          name: mongodb-log
-          path: $RUNNER_TEMP/mongodb-log
 
   validate_declarations:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - run: |
           git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: ankane/setup-mongodb@v1
+      - uses: ankane/setup-mongodb@ce30d9041565cb469945895d5bde3384a254dd2e # use commit ID until action is versioned, see https://github.com/ankane/setup-mongodb/issues/2
         with:
           mongodb-version: 5.0
       - uses: actions/setup-node@v2


### PR DESCRIPTION
This changeset simplifies cross-platform setup, at the expenses of adding a dependency. I am not certain this is worth it, but wanted to consolidate some of my discoveries from #904.