### PR TITLE
Use third-party action to deploy with Ansible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,22 +29,12 @@ jobs:
         instance: ${{ fromJSON(needs.get_instances.outputs.names) }}
     steps:
       - uses: actions/checkout@v2
-      - name: Get target server hostname
-        id: get_hostname
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq ".all.children.production.children.${{ matrix.instance }}.hosts.* | key" ops/inventories/production.yml
-      - name: Get target server fingerprint
-        id: get_fingerprint
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.all.children.production.children.${{ matrix.instance }}.hosts.["${{ steps.get_hostname.outputs.result }}"].ed25519_fingerprint' ops/inventories/production.yml
-      - name: Set up SSH
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SERVER_SSH_KEY }}
-          known_hosts: ${{ steps.get_hostname.outputs.result }} ssh-ed25519 ${{ steps.get_fingerprint.outputs.result }}
       - run: echo "${{ secrets.ANSIBLE_VAULT_KEY }}" > vault.key
-      - run: pip install --upgrade setuptools
-      - run: pip install 'ansible ~= 2.9'
-      - run: ansible-playbook ops/site.yml --inventory ops/inventories/production.yml --limit ${{ matrix.instance }}
+      - name: Deploy with Ansible
+        uses: saubermacherag/ansible-playbook-docker-action@v1.4
+        with:
+          playbookName: ops/site.yml
+          inventoryFile: ops/inventories/production.yml
+          keyFile: ops/roles/infra/files/ota-bot-key.private_key
+          keyFileVaultPass: ${{ secrets.ANSIBLE_VAULT_KEY }}
+          extraVars: --limit ${{ matrix.instance }}

--- a/ops/inventories/production.yml
+++ b/ops/inventories/production.yml
@@ -10,7 +10,6 @@ all:
     ota_repository: https://github.com/ambanum/OpenTermsArchive.git
     ota_branch: main
     app_config: "{{ lookup('file','../config/{{config_file_name}}.json') | from_json }}"
-    ed25519_fingerprint: False  # obtain this information with `ssh-keyscan -t ssh-ed25519 $host_ip_or_domain`
   children:
     production:
       children:
@@ -18,31 +17,25 @@ all:
           hosts:
             198.244.153.104:
               config_file_name: contrib
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIITN8hTCst7+6mHNzeo465crCZwHrc/SzUL1410mb9Lv
         dating:
           hosts:
             vps-99ae1d89.vps.ovh.net:
               config_file_name: dating
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIClFdaZhaXFmxdQI+rNSOsZaSlrgPlK9UzyGvi66u88V
         france:
           hosts:
             198.244.142.9:
               config_file_name: france
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIKH7P9SCnnSiVOhGMNvHIjWw5+3TYlmgmTK45Y9d1aCu
         france_elections:
           hosts:
             198.244.140.194:
               config_file_name: france-elections
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAINVdbg1Xualy2P6VB4mTMDGpUlKe9p+J8PViDAK08l7L
         pga:
           hosts:
             134.102.58.70:
               ansible_user: pga
               config_file_name: pga
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIDmKHW4LMOEIxnBHkdNzwvSrzjmfhQkx5n2lFtJdraOy
         p2b_compliance:
           hosts:
             vps-463f0baf.vps.ovh.net:
               ansible_user: ota
               config_file_name: p2b-compliance
-              ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIDOrkEl2aR2gJe0XmLy4j+0/51G/kAlkupfU4S2Qv0dJ


### PR DESCRIPTION
This changeset speeds up deployment by ~1 minute by avoiding installing Ansible on the runner by using Docker to avoid reinstalling every time, greatly simplifies the CI workflow declaration, and simplifies the inventory maintenance by removing entirely the need to update hosts fingerprints (yes, that makes most of #899 obsolete :wink:).

This [has been tested](https://github.com/ambanum/OpenTermsArchive/actions/runs/2918678773) and proven to work.

The only drawback from this solution is that we depend on a third party to update Ansible, and this is unlikely to happen (cf. https://github.com/saubermacherag/ansible-playbook-docker-action/issues/11). We also open up more of a security risk. We could mitigate both issues by forking and maintaining that action ourselves. I am not sure which of the three options (status quo, third-party, fork) is preferable.