### PR TITLE
Fix continuous deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         id: get_production_instances_names
         uses: mikefarah/yq@master
         with:
-          cmd: yq '. | keys' ops/inventories/production.yml --output-format=json
+          cmd: yq 'with_entries(select(.key | test("all") | not)) | keys' ops/inventories/production.yml --output-format=json  # list all group names except `all`
 
   deploy:
     needs: [ test, get_instances ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         id: get_production_instances_names
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.all.children | keys' ops/inventories/production.yml --output-format=json
+          cmd: yq '. | keys' ops/inventories/production.yml --output-format=json
 
   deploy:
     needs: [ test, get_instances ]
@@ -33,12 +33,12 @@ jobs:
         id: get_hostname
         uses: mikefarah/yq@master
         with:
-          cmd: yq ".all.children.production.children.${{ matrix.instance }}.hosts.* | key" ops/inventories/production.yml
+          cmd: yq ".${{ matrix.instance }}.hosts.* | key" ops/inventories/production.yml
       - name: Get target server fingerprint
         id: get_fingerprint
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.all.children.production.children.${{ matrix.instance }}.hosts.["${{ steps.get_hostname.outputs.result }}"].ed25519_fingerprint' ops/inventories/production.yml
+          cmd: yq '.${{ matrix.instance }}.hosts.["${{ steps.get_hostname.outputs.result }}"].ed25519_fingerprint' ops/inventories/production.yml
       - name: Set up SSH
         uses: shimataro/ssh-key-action@v2
         with:

--- a/ops/inventories/production.yml
+++ b/ops/inventories/production.yml
@@ -26,3 +26,7 @@ p2b_compliance:
       ansible_user: ota
       ed25519_fingerprint: AAAAC3NzaC1lZDI1NTE5AAAAIDOrkEl2aR2gJe0XmLy4j+0/51G/kAlkupfU4S2Qv0dJ
       config_file_name: p2b-compliance
+
+all:
+  vars:
+    ansible_user: debian

--- a/ops/roles/ota/defaults/main.yml
+++ b/ops/roles/ota/defaults/main.yml
@@ -1,5 +1,3 @@
-ansible_user: debian
-
 # Try out experimental features by deploying alternative versions of the engine, configuration or databases
 ota_repository: https://github.com/ambanum/OpenTermsArchive.git
 ota_branch: main


### PR DESCRIPTION
Following #908 improvements after initial review, the continuous deployment workflow was not tested and failed. The root cause was the YAML selectors that were not up to date. Once fixed, another issue was identified: the `site` playbook did not benefit from the default `ansible_user` that was set only for the `ota` role, preventing SSH connection when played.