### PR TITLE
Revert deletion of mandatory production file

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,27 @@
+{
+  "recorder": {
+    "versions": {
+      "storage": {
+        "git": {
+          "path": "../versions",
+          "publish": true
+        }
+      }
+    },
+    "snapshots": {
+      "storage": {
+        "git": {
+          "path": "../snapshots",
+          "publish": true
+        }
+      }
+    }
+  },
+  "logger": {
+    "sendMailOnError": {
+      "to": "admin@opentermsarchive.org",
+      "from": "noreply@opentermsarchive.org",
+      "sendWarnings": false
+    }
+  }
+}


### PR DESCRIPTION
Config production file allows factorizing some configuration keys which are the same for all instances when ran in the production environment.

Deleted in [cab3ea2ff47bb115e64c21528d60faf3935d054b](https://github.com/ambanum/OpenTermsArchive/pull/908/commits/cab3ea2ff47bb115e64c21528d60faf3935d054b).
