### PR TITLE
Add Ranking Parameters Description document type

### DIFF
--- a/src/archivist/services/documentTypes.json
+++ b/src/archivist/services/documentTypes.json
@@ -333,6 +333,11 @@
       "writer": "search engine or intermediation service provider",
       "audience": "users presented with a list of ranked results, or contributors of results that are ranked",
       "object": "parameters determining ranking and the reasons for their relative importance"
+    },
+    "references": {
+      "Article 5 of P2B Regulation 2019/1150": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32019R1150#d1e868-57-1",
+      "Article 6a of Directive 2011/83/EU": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02011L0083-20220528#tocId12",
+      "Point (m) of Article 2(1) of Directive 2005/29/EC": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02005L0029-20220528#tocId5"
     }
   }
 }

--- a/src/archivist/services/documentTypes.json
+++ b/src/archivist/services/documentTypes.json
@@ -330,7 +330,7 @@
   },
   "Ranking Parameters Description": {
     "commitment": {
-      "writer": "listing service provider",
+      "writer": "search engine or intermediation service provider",
       "audience": "users presented with a list of ranked results, or contributors of results that are ranked",
       "object": "parameters determining ranking and the reasons for their relative importance"
     }

--- a/src/archivist/services/documentTypes.json
+++ b/src/archivist/services/documentTypes.json
@@ -146,7 +146,7 @@
       "object": "expressions of desire, requests for a romantic or sexual relationship"
     }
   },
-    "Community Guidelines - Intellectual Property": {
+  "Community Guidelines - Intellectual Property": {
     "commitment": {
       "writer": "service provider",
       "audience": "content-publishing user",
@@ -326,6 +326,13 @@
       "writer": "online marketplace",
       "audience": "seller",
       "object": "selling through a monetary transaction goods or services to buyers other than the marketplace itself"
+    }
+  },
+  "Ranking Parameters Description": {
+    "commitment": {
+      "writer": "listing service provider",
+      "audience": "users presented with a list of ranked results, or contributors of results that are ranked",
+      "object": "parameters determining ranking and the reasons for their relative importance"
     }
   }
 }

--- a/src/archivist/services/documentTypes.json
+++ b/src/archivist/services/documentTypes.json
@@ -335,6 +335,7 @@
       "object": "parameters determining ranking and the reasons for their relative importance"
     },
     "references": {
+      "Open Terms Archive Discussion": "https://github.com/ambanum/OpenTermsArchive/discussions/902",
       "Article 5 of P2B Regulation 2019/1150": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32019R1150#d1e868-57-1",
       "Article 6a of Directive 2011/83/EU": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02011L0083-20220528#tocId12",
       "Point (m) of Article 2(1) of Directive 2005/29/EC": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02005L0029-20220528#tocId5"


### PR DESCRIPTION
Follows https://github.com/ambanum/OpenTermsArchive/discussions/902.

This changeset also introduces the `references` key in the document types, to give more context and legal background to a document type.