### PR TITLE
Notify GitHub errors once

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -143,7 +143,7 @@ export default class Tracker {
       if (!existingIssues.length) {
         const existingIssue = await this.createIssue({ ...this.commonParams, title, body, labels });
 
-        logger.info(`🤖 Creating Github issue for ${title}: ${existingIssue.html_url}`);
+        logger.info(`🤖 Creating GitHub issue for ${title}: ${existingIssue.html_url}`);
 
         return;
       }
@@ -168,13 +168,13 @@ export default class Tracker {
             /* eslint-enable no-await-in-loop */
             logger.info(`🤖 Reopened automatically as an error occured for ${title}: ${existingIssue.html_url}`);
           } catch (e) {
-            logger.error(`🤖 Could not update Github issue ${existingIssue.html_url}. ${e.toString()}`);
+            logger.error(`🤖 Could not update GitHub issue ${existingIssue.html_url}: ${e}`);
           }
           break;
         }
       }
     } catch (e) {
-      logger.error(`🤖 Could not create Github issue for ${title}. ${e.toString()}`);
+      logger.error(`🤖 Could not create GitHub issue for ${title}: ${e}`);
     }
   }
 
@@ -186,13 +186,13 @@ export default class Tracker {
         try {
           await this.octokit.rest.issues.update({ ...this.commonParams, issue_number: openedIssue.number, state: ISSUE_STATE_CLOSED }); // eslint-disable-line no-await-in-loop
           await this.addCommentToIssue({ ...this.commonParams, issue_number: openedIssue.number, body: comment }); // eslint-disable-line no-await-in-loop
-          logger.info(`🤖 Github issue closed for ${title}: ${openedIssue.html_url}`);
+          logger.info(`🤖 GitHub issue closed for ${title}: ${openedIssue.html_url}`);
         } catch (e) {
-          logger.error(`🤖 Could not close Github issue ${openedIssue.html_url}. ${e.toString()}`);
+          logger.error(`🤖 Could not close GitHub issue ${openedIssue.html_url}: ${e.toString()}`);
         }
       }
     } catch (e) {
-      logger.error(`🤖 Could not close Github issues for ${title}. ${e.toString()}`);
+      logger.error(`🤖 Could not close GitHub issue for ${title}: ${e}`);
     }
   }
 

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -143,11 +143,7 @@ export default class Tracker {
       if (!existingIssues.length) {
         const existingIssue = await this.createIssue({ ...this.commonParams, title, body, labels });
 
-        if (existingIssue) {
-          logger.info(`🤖 Creating Github issue for ${title}: ${existingIssue.html_url}`);
-        } else {
-          logger.error(`🤖 Could not create Github issue for ${title}`);
-        }
+        logger.info(`🤖 Creating Github issue for ${title}: ${existingIssue.html_url}`);
 
         return;
       }
@@ -177,10 +173,8 @@ export default class Tracker {
           break;
         }
       }
-
-      return;
     } catch (e) {
-      logger.error('Could not create issue', e.toString());
+      logger.error(`🤖 Could not create Github issue for ${title}. ${e.toString()}`);
     }
   }
 

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -162,7 +162,7 @@ export default class Tracker {
           logger.error(`🤖 Could not create Github issue for ${title}`);
         }
 
-        return existingIssue;
+        return;
       }
 
       const openedIssues = existingIssues.filter(existingIssue => existingIssue.state === ISSUE_STATE_OPEN);
@@ -187,7 +187,7 @@ export default class Tracker {
         }
       }
 
-      return existingIssues;
+      return;
     } catch (e) {
       logger.error('Could not create issue', e.toString());
     }

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -157,19 +157,23 @@ export default class Tracker {
 
       for (const existingIssue of existingIssues) {
         if (hasNoneOpened) {
-          /* eslint-disable no-await-in-loop */
-          await this.octokit.rest.issues.update({
-            ...this.commonParams,
-            issue_number: existingIssue.number,
-            state: ISSUE_STATE_OPEN,
-          });
-          await this.addCommentToIssue({
-            ...this.commonParams,
-            issue_number: existingIssue.number,
-            body: `${comment}\n${body}`,
-          });
-          /* eslint-enable no-await-in-loop */
-          logger.info(`🤖 Reopened automatically as an error occured for ${title}: ${existingIssue.html_url}`);
+          try {
+            /* eslint-disable no-await-in-loop */
+            await this.octokit.rest.issues.update({
+              ...this.commonParams,
+              issue_number: existingIssue.number,
+              state: ISSUE_STATE_OPEN,
+            });
+            await this.addCommentToIssue({
+              ...this.commonParams,
+              issue_number: existingIssue.number,
+              body: `${comment}\n${body}`,
+            });
+            /* eslint-enable no-await-in-loop */
+            logger.info(`🤖 Reopened automatically as an error occured for ${title}: ${existingIssue.html_url}`);
+          } catch (e) {
+            logger.error(`🤖 Could not update Github issue ${existingIssue.html_url}. ${e.toString()}`);
+          }
           break;
         }
       }

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -102,39 +102,26 @@ export default class Tracker {
   }
 
   async createIssue(params) {
-    try {
-      const { data } = await this.octokit.rest.issues.create(params);
+    const { data } = await this.octokit.rest.issues.create(params);
 
-      return data;
-    } catch (e) {
-      logger.error('Could not create issue');
-      logger.error(e.toString());
-
-      return null;
-    }
+    return data;
   }
 
   async searchIssues({ title, ...searchParams }) {
-    try {
-      const request = {
-        per_page: 100,
-        ...searchParams,
-      };
+    const request = {
+      per_page: 100,
+      ...searchParams,
+    };
 
-      const issues = await this.octokit.paginate(
-        this.octokit.rest.issues.listForRepo,
-        request,
-        response => response.data,
-      );
+    const issues = await this.octokit.paginate(
+      this.octokit.rest.issues.listForRepo,
+      request,
+      response => response.data,
+    );
 
-      const issuesWithSameTitle = issues.filter(item => item.title === title);
+    const issuesWithSameTitle = issues.filter(item => item.title === title);
 
-      return issuesWithSameTitle;
-    } catch (e) {
-      logger.error('Could not search issue');
-      logger.error(e.toString());
-      throw e;
-    }
+    return issuesWithSameTitle;
   }
 
   async addCommentToIssue(params) {

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -125,15 +125,9 @@ export default class Tracker {
   }
 
   async addCommentToIssue(params) {
-    try {
-      const { data } = await this.octokit.rest.issues.createComment(params);
+    const { data } = await this.octokit.rest.issues.createComment(params);
 
-      return data;
-    } catch (e) {
-      logger.error('Could not add comment to issue:', e.toString());
-
-      return null;
-    }
+    return data;
   }
 
   async createIssueIfNotExists({ title, body, labels, comment }) {


### PR DESCRIPTION
Fixes #926

The use of `logger.error` implies the sending of an email to the administrators so we need to keep only once per error encountered.

Also add more granularity to errors to know exactly which error occured