### PR TITLE
Expose page declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ You can use the filter in your code by using `import filter from 'open-terms-arc
 
 The `filter` function documentation is available as JSDoc within [./src/archivist/filter/index.js](./src/archivist/filter/index.js).
 
+#### page-declaration
+
+PageDeclaration object is used to describe a page to be tracked by Open Terms Archive.
+
+You can use the page-declaration in your code by using `import pageDeclaration from 'open-terms-archive/page-declaration';`.
+
 ## Using locally
 
 ### Installing

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     "./fetch": "./src/archivist/fetcher/exports.js",
     "./filter": "./src/archivist/filter/exports.js",
-    "./document-declaration": "./src/archivist/services/documentDeclaration.js"
+    "./document-declaration": "./src/archivist/services/documentDeclaration.js",
+    "./page-declaration": "./src/archivist/services/pageDeclaration.js"
   },
   "bin": {
     "ota-lint-declarations": "./bin/lint-declarations.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "exports": {
     "./fetch": "./src/archivist/fetcher/exports.js",
     "./filter": "./src/archivist/filter/exports.js",
-    "./document-declaration": "./src/archivist/services/documentDeclaration.js",
     "./page-declaration": "./src/archivist/services/pageDeclaration.js"
   },
   "bin": {


### PR DESCRIPTION
When multi page feature was added, signature of document declaration export should have been changed to page declaration.