### PR TITLE
Automate package release with Semantic versioning

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: Changelog check
+name: Check changelog
 
 on:
   push:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Changelog check
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - push-action/** # Temporary branches created by CasperWA/push-protected@v2 action on release workflow
+  pull_request:
+    types: [ opened, reopened ]
+  workflow_call:
+    outputs:
+      release_type:
+        description: The release type extracted from changelog
+        value: ${{ jobs.check_changelog.outputs.release_type }}
+
+jobs:
+  check_changelog:
+    runs-on: [ ubuntu-latest ]
+    outputs:
+      release_type: ${{ steps.set_release_type_output.outputs.release_type }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get release type in changelog
+        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major" | tr -d '\n')" >> $GITHUB_ENV
+      - name: Make release type available to subsequent jobs
+        if: env.RELEASE_TYPE
+        id: set_release_type_output
+        run: |
+          echo "Found release type '${{ env.RELEASE_TYPE }}'"
+          echo "release_type=${{ env.RELEASE_TYPE }}" >> $GITHUB_OUTPUT
+      - name: Fail and display error if no proper release type is found in changelog
+        if: env.RELEASE_TYPE == ''
+        run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tags '[patch]', '[minor]', '[major]'. For example, '## Unreleased [minor]'."; exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-type:
-        type: choice
-        description: Release type
-        options:
-        - patch
-        - minor
-        - major
-        - prepatch
-        - preminor
-        - premajor
-        - prerelease
-        
+  push:
+    branches: [ main ]
+
 jobs:
   test:
     uses: "ambanum/OpenTermsArchive/.github/workflows/test.yml@main"
@@ -28,24 +17,16 @@ jobs:
       - name: Git configuration
         run: |
           git config --global user.name "GitHub Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Get release type
+        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep '## Unreleased' | sed -r 's/^## Unreleased \[(patch|minor|major)\]/\1/g')" >> $GITHUB_ENV
+          
 
       - name: Bump package version
-        if: startsWith(github.event.inputs.release-type, 'pre') != true
         run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ env.RELEASE_TYPE }})" >> $GITHUB_ENV
           echo "RELEASE_TAG=latest" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
-
-      - name: Bump package pre-release version
-        # Use tag "beta" for pre-release versions
-        if: startsWith(github.event.inputs.release-type, 'pre')
-        run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_TYPE)" >> $GITHUB_ENV
-          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
 
       - name: Update changelog unreleased section with new version
         uses: superfaceai/release-changelog-action@v1
@@ -64,16 +45,6 @@ jobs:
 
       - name: Add authentication token for NPM
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_ACCESS_TOKEN }}" > ~/.npmrc
-      
-      - name: Publish version to public repository
-        run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
-
-      - name: Push changes to repository
-        run: git push origin && git push --tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read version changelog
         uses: superfaceai/release-changelog-action@v1
@@ -83,11 +54,20 @@ jobs:
           version: ${{ env.NEW_VERSION }}
           operation: read
 
+      - name: Push changes to repository
+        run: git push origin && git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update GitHub release with changelog
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.NEW_VERSION }}
           body: ${{ steps.get-changelog.outputs.changelog }}
-          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish version to public repository
+        run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,6 @@ jobs:
           git commit -m "Release ${{ env.NEW_VERSION }}"
           git tag ${{ env.NEW_VERSION }}
 
-      - name: Add authentication token for NPM
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_ACCESS_TOKEN }}" > ~/.npmrc
-
       - name: Read version changelog
         uses: superfaceai/release-changelog-action@v1
         id: get-changelog
@@ -67,7 +64,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish version to public repository
+      - name: Setup Node to allow publishing to NPM
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish version to NPM public repository
         run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,8 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@users.noreply.github.com"
 
-      - name: Get release type
-        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep '## Unreleased' | sed -r 's/^## Unreleased \[(patch|minor|major)\]/\1/g')" >> $GITHUB_ENV
-          
+      - name: Get release type from the changelog
+        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major")" >> $GITHUB_ENV
 
       - name: Bump package version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,20 @@
 name: Release
 
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    branches: 
+      - main
+    types: [ closed ]
+
 
 jobs:
+  changelog:
+    uses: "ambanum/OpenTermsArchive/.github/workflows/changelog.yml@main"
   test:
     uses: "ambanum/OpenTermsArchive/.github/workflows/test.yml@main"
   release:
-    needs: [ test ]
+    if: github.event.pull_request.merged == true
+    needs: [ changelog, test ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,8 +29,8 @@ jobs:
 
       - name: Bump package version
         run: |
-          echo "Release type obtained from the previous job: '${{ needs.test.outputs.release_type }}'"
-          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ needs.test.outputs.release_type }})" >> $GITHUB_ENV
+          echo "Release type obtained from the previous job: '${{ needs.changelog.outputs.release_type }}'"
+          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ needs.changelog.outputs.release_type }})" >> $GITHUB_ENV
 
       - name: Update changelog unreleased section with new version
         uses: superfaceai/release-changelog-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node to allow publishing to NPM
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Publish version to NPM public repository
-        run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,8 @@ jobs:
           echo "RELEASE_TAG=latest" >> $GITHUB_ENV
 
       - name: Update changelog unreleased section with new version
-        uses: superfaceai/release-changelog-action@v1
+        uses: superfaceai/release-changelog-action@v2
         with:
-          path-to-changelog: CHANGELOG.md
           version: ${{ env.NEW_VERSION }}
           operation: release
 
@@ -44,10 +43,9 @@ jobs:
           git tag ${{ env.NEW_VERSION }}
 
       - name: Read version changelog
-        uses: superfaceai/release-changelog-action@v1
+        uses: superfaceai/release-changelog-action@v2
         id: get-changelog
         with:
-          path-to-changelog: CHANGELOG.md
           version: ${{ env.NEW_VERSION }}
           operation: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update GitHub release with changelog
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.NEW_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: Release type
+        options:
+        - patch
+        - minor
+        - major
+        - prepatch
+        - preminor
+        - premajor
+        - prerelease
+        
+jobs:
+  test:
+    uses: "ambanum/OpenTermsArchive/.github/workflows/test.yml@main"
+  release:
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Git configuration
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
+      - name: Bump package version
+        if: startsWith(github.event.inputs.release-type, 'pre') != true
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      - name: Bump package pre-release version
+        # Use tag "beta" for pre-release versions
+        if: startsWith(github.event.inputs.release-type, 'pre')
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      - name: Update changelog unreleased section with new version
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: release
+
+      - name: Commit CHANGELOG.md and package.json changes and create tag
+        run: |
+          git add "package.json"
+          git add "package-lock.json"
+          git add "CHANGELOG.md"
+          git commit -m "Release ${{ env.NEW_VERSION }}"
+          git tag ${{ env.NEW_VERSION }}
+
+      - name: Add authentication token for NPM
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_ACCESS_TOKEN }}" > ~/.npmrc
+      
+      - name: Publish version to public repository
+        run: npm publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+
+      - name: Push changes to repository
+        run: git push origin && git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version changelog
+        uses: superfaceai/release-changelog-action@v1
+        id: get-changelog
+        with:
+          path-to-changelog: CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: read
+
+      - name: Update GitHub release with changelog
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.NEW_VERSION }}
+          body: ${{ steps.get-changelog.outputs.changelog }}
+          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,22 @@ jobs:
           git commit -m "Release ${{ env.NEW_VERSION }}"
           git tag ${{ env.NEW_VERSION }}
 
+      - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks 
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          branch: main
+          unprotect_reviews: true
+
+      - name: Push changes to repository
+        run: git push origin && git push --tags
+
       - name: Read version changelog
         uses: superfaceai/release-changelog-action@v2
         id: get-changelog
         with:
           version: ${{ env.NEW_VERSION }}
           operation: read
-
-      - name: Push changes to repository
-        run: git push origin && git push --tags
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Git configuration
+      - name: Configure Git author
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           body: ${{ steps.get-changelog.outputs.changelog }}
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: Publish version to NPM public repository
+      - name: Publish to NPM public repository
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,10 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@users.noreply.github.com"
 
-      - name: Get release type from the changelog
-        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major")" >> $GITHUB_ENV
-
       - name: Bump package version
-        run: echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ env.RELEASE_TYPE }})" >> $GITHUB_ENV
+        run: |
+          echo "Release type obtained from the previous job: '${{ needs.test.outputs.release_type }}'"
+          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ needs.test.outputs.release_type }})" >> $GITHUB_ENV
 
       - name: Update changelog unreleased section with new version
         uses: superfaceai/release-changelog-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Configure Git author
         run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "github-actions@users.noreply.github.com"
+          git config --global user.name "Open Terms Archive Release Bot"
+          git config --global user.email "release-bot@opentermsarchive.org"
 
       - name: Bump package version
         run: |
@@ -47,16 +49,13 @@ jobs:
 
       - name: Push changes to repository
         run: git push origin && git push --tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.NEW_VERSION }}
           body: ${{ steps.get-changelog.outputs.changelog }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Publish version to NPM public repository
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,7 @@ jobs:
         run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major")" >> $GITHUB_ENV
 
       - name: Bump package version
-        run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ env.RELEASE_TYPE }})" >> $GITHUB_ENV
-          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        run: echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ env.RELEASE_TYPE }})" >> $GITHUB_ENV
 
       - name: Update changelog unreleased section with new version
         uses: superfaceai/release-changelog-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
         run: |
           echo "Found release type '${{ env.RELEASE_TYPE }}'"
           echo "release_type=${{ env.RELEASE_TYPE }}" >> $GITHUB_OUTPUT
-      - name: Fail and display error is proper release type is not found in changelog
+      - name: Fail and display error if no proper release type is found in changelog
         if: env.RELEASE_TYPE == ''
-        run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tag [patch], [minor], [major]. Ex Unreleased [minor]."; exit 1
+        run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tags '[patch]', '[minor]', '[major]'. For example, '## Unreleased [minor]'."; exit 1
 
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,14 @@ on:
 
 jobs:
   check_changelog:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check for proper release type in changelog
-        run: $(cat CHANGELOG.md | grep '## Unreleased \[.*\]' | grep -E -w -o -q "patch|minor|major") || (echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tag [patch], [minor], [major]. Ex Unreleased [minor]."; exit 1)
+      - name: Get release type in changelog
+        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major" | tr -d '\n')" >> $GITHUB_ENV
+      - name: Fail and display error if proper release type is not found in the changelog
+        if: env.RELEASE_TYPE == ''
+        run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tag [patch], [minor], [major]. Ex Unreleased [minor]."; exit 1
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,31 +7,8 @@ on:
   pull_request:
     types: [ opened, reopened ]
   workflow_call:
-    outputs:
-      release_type:
-        description: "The release type extracted from changelog"
-        value: ${{ jobs.check_changelog.outputs.release_type }}
 
 jobs:
-  check_changelog:
-    runs-on: [ubuntu-latest]
-    outputs:
-      release_type: ${{ steps.set_release_type_output.outputs.release_type }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get release type in changelog
-        run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major" | tr -d '\n')" >> $GITHUB_ENV
-      - name: Make release type available to subsequent jobs
-        if: env.RELEASE_TYPE
-        id: set_release_type_output
-        run: |
-          echo "Found release type '${{ env.RELEASE_TYPE }}'"
-          echo "release_type=${{ env.RELEASE_TYPE }}" >> $GITHUB_OUTPUT
-      - name: Fail and display error if no proper release type is found in changelog
-        if: env.RELEASE_TYPE == ''
-        run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tags '[patch]', '[minor]', '[major]'. For example, '## Unreleased [minor]'."; exit 1
-
-
   test:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,30 @@ on:
   pull_request:
     types: [ opened, reopened ]
   workflow_call:
+    outputs:
+      release_type:
+        description: "The release type extracted from changelog"
+        value: ${{ jobs.check_changelog.outputs.release_type }}
 
 jobs:
   check_changelog:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest]
+    outputs:
+      release_type: ${{ steps.set_release_type_output.outputs.release_type }}
     steps:
       - uses: actions/checkout@v2
       - name: Get release type in changelog
         run: echo "RELEASE_TYPE=$(cat CHANGELOG.md | grep -E '^## Unreleased \[(patch|minor|major)\]$' | grep -E -w -o "patch|minor|major" | tr -d '\n')" >> $GITHUB_ENV
-      - name: Fail and display error if proper release type is not found in the changelog
+      - name: Make release type available to subsequent jobs
+        if: env.RELEASE_TYPE
+        id: set_release_type_output
+        run: |
+          echo "Found release type '${{ env.RELEASE_TYPE }}'"
+          echo "release_type=${{ env.RELEASE_TYPE }}" >> $GITHUB_OUTPUT
+      - name: Fail and display error is proper release type is not found in changelog
         if: env.RELEASE_TYPE == ''
         run: echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tag [patch], [minor], [major]. Ex Unreleased [minor]."; exit 1
+
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ on:
   workflow_call:
 
 jobs:
+  check_changelog:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for proper release type in changelog
+        run: $(cat CHANGELOG.md | grep '## Unreleased \[.*\]' | grep -E -w -o -q "patch|minor|major") || (echo "No valid release type found in changelog. The title of the 'Unreleased' section must contain one of the following tag [patch], [minor], [major]. Ex Unreleased [minor]."; exit 1)
+
   test:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
+Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the following: `[patch]`, `[minor]`, `[major]`. Ex `Unreleased [minor]`.
 
-## [Unreleased]
+## [Unreleased][minor]
 
 ### Added
 
-- Automate npm publishing with GitHub Actions
+- Automate release with GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
-Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the following: `[patch]`, `[minor]`, `[major]`. Ex `Unreleased [minor]`.
+Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the names mandated by SemVer, within brackets: `[patch]`, `[minor]` or `[major]`. For example: `## Unreleased [minor]`.
 
 ## Unreleased [minor]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
 Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the following: `[patch]`, `[minor]`, `[major]`. Ex `Unreleased [minor]`.
 
-## [Unreleased][minor]
+## Unreleased [minor]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,6 @@ Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://
 
 ### Added
 
-- Automate release with GitHub Actions
+- Publish package on NPM under name `opentermsarchive`.
+- Export `filter`, `pageDeclaration` and `fetch` in NPM module.
+- Add changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Automate npm publishing with GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://
 
 ### Added
 
-- Publish package on NPM under name `opentermsarchive`.
+- Publish package on NPM under name `@opentermsarchive/engine`.
 - Export `filter`, `pageDeclaration` and `fetch` in NPM module.
 - Add changelog.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ First of all, thanks for taking the time to contribute! 🎉👍
   - [Pull requests](#pull-requests)
   - [Commit messages](#commit-messages)
   - [Continuous delivery](#continuous-delivery)
+  - [Changelog](#changelog)
 - [Development](#development)
   - [Documentation](#documentation)
 - [Naming](#naming)
@@ -51,6 +52,10 @@ We strive to follow this [recommendation](https://chris.beams.io/posts/git-commi
 We add this additional rule:
 
 - Do not rely on GitHub issue reference numbers in commit messages, as we have no guarantee the host system and its autolinking will be stable in time. Make sure the context is self-explanatory. If an external reference is given, use its full URL.
+
+### Changelog
+
+All notable changes to this project must be documented in the [`CHANGELOG.md`](./CHANGELOG.md) file.
 
 ## Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ We add this additional rule:
 
 ### Changelog
 
-All notable changes to this project must be documented in the [`CHANGELOG.md`](./CHANGELOG.md) file.
+All changes to the codebase that impact users must be documented in the [`CHANGELOG.md`](./CHANGELOG.md) file. The format to use is documented in the file itself.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "open-terms-archive",
+  "name": "opentermsarchive",
   "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-terms-archive",
+      "name": "opentermsarchive",
       "version": "0.15.0",
       "license": "EUPL-1.2",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "ambanum",
   "type": "module",
   "exports": {
+    ".": "./src/exports.js",
     "./fetch": "./src/archivist/fetcher/exports.js",
     "./filter": "./src/archivist/filter/exports.js",
     "./page-declaration": "./src/archivist/services/pageDeclaration.js"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
     "posttest": "npm run lint",
     "test:debug": "npm run test -- --inspect-brk --exit"
   },
+  "files": [
+    "bin",
+    "config",
+    "scripts",
+    "src"
+  ],
   "dependencies": {
     "@accordproject/markdown-cicero": "^0.15.2",
     "@accordproject/markdown-pdf": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentermsarchive/engine",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Tracks and makes visible changes to the terms of online services",
   "homepage": "https://github.com/ambanum/OpenTermsArchive#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-terms-archive",
+  "name": "opentermsarchive",
   "version": "0.15.0",
   "description": "Tracks and makes visible changes to the Terms of Service of online service",
   "homepage": "https://github.com/ambanum/OpenTermsArchive#readme",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opentermsarchive",
+  "name": "@opentermsarchive/engine",
   "version": "0.15.0",
   "description": "Tracks and makes visible changes to the terms of online services",
   "homepage": "https://github.com/ambanum/OpenTermsArchive#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opentermsarchive",
   "version": "0.15.0",
-  "description": "Tracks and makes visible changes to the Terms of Service of online service",
+  "description": "Tracks and makes visible changes to the terms of online services",
   "homepage": "https://github.com/ambanum/OpenTermsArchive#readme",
   "bugs": {
     "url": "https://github.com/ambanum/OpenTermsArchive/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-terms-archive",
   "version": "0.15.0",
-  "description": "Tracks and makes visible all changes to the Terms Of Service of online service providers.",
+  "description": "Tracks and makes visible changes to the Terms of Service of online service",
   "homepage": "https://github.com/ambanum/OpenTermsArchive#readme",
   "bugs": {
     "url": "https://github.com/ambanum/OpenTermsArchive/issues"

--- a/src/archivist/recorder/repositories/git/index.test.js
+++ b/src/archivist/recorder/repositories/git/index.test.js
@@ -471,7 +471,9 @@ describe('GitRepository', () => {
     let records;
     const expectedIds = [];
 
-    before(async () => {
+    before(async function () {
+      this.timeout(5000);
+
       const { id: id1 } = await subject.save(new Record({
         serviceId: SERVICE_PROVIDER_ID,
         documentType: DOCUMENT_TYPE,
@@ -529,7 +531,9 @@ describe('GitRepository', () => {
   describe('#count', () => {
     let count;
 
-    before(async () => {
+    before(async function () {
+      this.timeout(5000);
+
       await subject.save(new Record({
         serviceId: SERVICE_PROVIDER_ID,
         documentType: DOCUMENT_TYPE,

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,0 +1,3 @@
+export { default as pageDeclaration } from './archivist/services/pageDeclaration.js';
+export { default as filter } from './archivist/filter/exports.js';
+export { default as fetch } from './archivist/fetcher/exports.js';


### PR DESCRIPTION
This PR trigger a package release on GitHub and NPM with an appropriate [version bump](https://docs.npmjs.com/cli/v8/commands/npm-version) when merged on the `main` branch.

Changelog file is based on [Common Changelog](https://common-changelog.org).