### PR TITLE
Handle all cases of email protection to prevent blinking and ease maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
 Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the names mandated by SemVer, within brackets: `[patch]`, `[minor]` or `[major]`. For example: `## Unreleased [minor]`.
 
-## Unreleased
+## Unreleased [minor]
+
+Full changeset and discussions: [#959](https://github.com/ambanum/OpenTermsArchive/pull/959)._
+
+### Changed
+
+- Improved reliability and expanded coverage of email protection global filter
 
 ## 0.19.1 - 2022-12-13
 ### Fixed

--- a/src/archivist/filter/index.js
+++ b/src/archivist/filter/index.js
@@ -84,9 +84,12 @@ export async function filterHTML({ content, pageDeclaration }) {
 
   // clean code from common changing patterns - initially for Windstream
   domFragment.querySelectorAll('a[href*="/email-protection"]').forEach(node => {
-    if (node.href.match(/((.*?)\/email-protection#)[0-9a-fA-F]+/gim)) {
-      node.href = `${node.href.split('#')[0]}#removed`;
-    }
+    const newProtectedLink = webPageDOM.createElement('a');
+    const [href] = node.href.split('#');
+
+    newProtectedLink.href = href;
+    newProtectedLink.innerHTML = '[email protected]';
+    node.parentNode.replaceChild(newProtectedLink, node);
   });
 
   const markdownContent = transform(domFragment);

--- a/src/archivist/filter/index.test.js
+++ b/src/archivist/filter/index.test.js
@@ -62,7 +62,7 @@ const rawHTMLWithCommonChangingItems = `
     <p><a id="link2" href="#anchor">link 2</a></p>
     <p><a id="link3" href="http://absolute.url/link">link 3</a></p>
     <p><a id="link4" href="">link 4</a></p>
-    <p><a href="/cdn-cgi/l/email-protection#3b4c52555f484f495e5a56154b49524d5a584215484f5a4f5e565e554f7b4c52555f484f495e5a5615585456">[email&#160;protected]</a></p>
+    <a href="/cdn-cgi/l/email-protection#3b4c52555f484f495e5a56154b49524d5a584215484f5a4f5e565e554f7b4c52555f484f495e5a5615585456">[email&#160;protected]</a>
     <p><a href="/cdn-cgi/l/email-protection#2d4e4243594c4e596d4e4459545e4e424259034858">conta<span>[email&#160;protected]</span></a></p>
   </body>
 </html>`;

--- a/src/archivist/filter/index.test.js
+++ b/src/archivist/filter/index.test.js
@@ -62,7 +62,7 @@ const rawHTMLWithCommonChangingItems = `
     <p><a id="link2" href="#anchor">link 2</a></p>
     <p><a id="link3" href="http://absolute.url/link">link 3</a></p>
     <p><a id="link4" href="">link 4</a></p>
-    <a href="/cdn-cgi/l/email-protection#3b4c52555f484f495e5a56154b49524d5a584215484f5a4f5e565e554f7b4c52555f484f495e5a5615585456">[email&#160;protected]</a>
+    <p><a href="/cdn-cgi/l/email-protection#3b4c52555f484f495e5a56154b49524d5a584215484f5a4f5e565e554f7b4c52555f484f495e5a5615585456">[email&#160;protected]</a></p>
   </body>
 </html>`;
 
@@ -78,7 +78,7 @@ const expectedFilteredWithCommonChangingItems = `Title
 
 link 4
 
-[\\[email protected\\]](https://exemple.com/cdn-cgi/l/email-protection#removed)`;
+[\\[email protected\\]](https://exemple.com/cdn-cgi/l/email-protection)`;
 /* eslint-enable no-irregular-whitespace */
 
 const additionalFilter = {

--- a/src/archivist/filter/index.test.js
+++ b/src/archivist/filter/index.test.js
@@ -63,6 +63,7 @@ const rawHTMLWithCommonChangingItems = `
     <p><a id="link3" href="http://absolute.url/link">link 3</a></p>
     <p><a id="link4" href="">link 4</a></p>
     <p><a href="/cdn-cgi/l/email-protection#3b4c52555f484f495e5a56154b49524d5a584215484f5a4f5e565e554f7b4c52555f484f495e5a5615585456">[email&#160;protected]</a></p>
+    <p><a href="/cdn-cgi/l/email-protection#2d4e4243594c4e596d4e4459545e4e424259034858">conta<span>[email&#160;protected]</span></a></p>
   </body>
 </html>`;
 
@@ -77,6 +78,8 @@ const expectedFilteredWithCommonChangingItems = `Title
 [link 3](http://absolute.url/link)
 
 link 4
+
+[\\[email protected\\]](https://exemple.com/cdn-cgi/l/email-protection)
 
 [\\[email protected\\]](https://exemple.com/cdn-cgi/l/email-protection)`;
 /* eslint-enable no-irregular-whitespace */


### PR DESCRIPTION
Here is an implementation of a global filter that aims at removing blink on several documents in an harmonized way.

For now, there has been an implementation that does not cover all cases and this lack of universality in the process is causing blinks on several instances and forcing contributors to [create a filter](https://github.com/OpenTermsArchive/p2b-compliance-declarations/blob/main/declarations/Fairbnb.coop.filters.js) for which we already have at least 3 versions.

Here are some affected documents

- [BlaBlaCar](https://github.com/OpenTermsArchive/france-versions/commit/724461ac41466ec152eb2501a7b0eb93b7821cb9)
- Cityscoot on France
- FairCoop on P2B
- and many others

Thanks to this PR, blink will not occur anymore on any instance and will remove the need of custom filters, thus improcing stability and maintainability


