### PR TITLE
Fix script to test only modified documents + simplify use in CI

### DIFF
--- a/scripts/declarations/utils/index.js
+++ b/scripts/declarations/utils/index.js
@@ -70,9 +70,12 @@ export default class DeclarationUtils {
         return acc;
       }, new Set());
 
-      servicesDocumentTypes[serviceId] = new Set([ ...servicesDocumentTypes[serviceId] || [], ...modifiedDocumentTypes ]);
+      servicesDocumentTypes[serviceId] = Array.from(new Set([ ...servicesDocumentTypes[serviceId] || [], ...modifiedDocumentTypes ]));
     }));
 
-    return { services: modifiedServiceIds, servicesDocumentTypes };
+    return {
+      services: Array.from(modifiedServiceIds),
+      servicesDocumentTypes,
+    };
   }
 }

--- a/scripts/declarations/utils/index.js
+++ b/scripts/declarations/utils/index.js
@@ -4,7 +4,7 @@ import DeepDiff from 'deep-diff';
 import simpleGit from 'simple-git';
 
 export default class DeclarationUtils {
-  constructor(instancePath, defaultBranch = 'main') {
+  constructor(instancePath, defaultBranch = 'remotes/origin/main') {
     this.git = simpleGit(instancePath, { maxConcurrentProcesses: 1 });
     this.defaultBranch = defaultBranch;
   }

--- a/scripts/declarations/utils/index.js
+++ b/scripts/declarations/utils/index.js
@@ -24,7 +24,7 @@ export default class DeclarationUtils {
 
     const modifiedFilePaths = modifiedFilePathsAsString ? modifiedFilePathsAsString.split('\n') : [];
 
-    return { modifiedFilePaths, modifiedServiceIds: new Set(modifiedFilePaths.map(DeclarationUtils.filePathToServiceId)) };
+    return { modifiedFilePaths, modifiedServiceIds: Array.from(new Set(modifiedFilePaths.map(DeclarationUtils.filePathToServiceId))) };
   }
 
   async getModifiedServices() {
@@ -74,7 +74,7 @@ export default class DeclarationUtils {
     }));
 
     return {
-      services: Array.from(modifiedServiceIds),
+      services: modifiedServiceIds,
       servicesDocumentTypes,
     };
   }


### PR DESCRIPTION
A bug has been introduced in https://github.com/ambanum/OpenTermsArchive/pull/958 that causes modified declarations to not be passed to the validate function, data being a `Set` while code is awaiting an `Array`.

This cause the tool to validate all document types within the service instead of only the ones modified.

This PR solves this problem 

It also changes the branch on which the diff is made to find out what document types were modified.

For now, the local `main` branch is used for the diff and in order to make this possible on CI, we need to add [this line](https://github.com/OpenTermsArchive/contrib-declarations/pull/694/files#r1019038409)

By changing the diff branch from `main` to `remotes/origin/main` in the core, this would remove the need for this line.
