### PR TITLE
Speed up and decrease costs of packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
     "posttest": "npm run lint",
     "test:debug": "npm run test -- --inspect-brk --exit"
   },
+  "files": [
+    "bin",
+    "config",
+    "scripts",
+    "src"
+  ],
   "dependencies": {
     "@accordproject/markdown-cicero": "^0.15.2",
     "@accordproject/markdown-pdf": "^0.15.2",


### PR DESCRIPTION
Avoid forcing dependents to download, decompress and store irrelevant files such as decision records or test files.
Decrease published size and upload and download speed by 50% and storage size by 30%:

```diff
- npm notice package size:  187.1 kB
+ npm notice package size:  89.0 kB
- npm notice unpacked size: 637.3 kB
+ npm notice unpacked size: 463.2 kB
- npm notice total files:   168
+ npm notice total files:   107
```