### PR TITLE
Fix GitHub issue link formatting

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -197,7 +197,7 @@ export default class Tracker {
     const body = `
 This document is no longer properly tracked.
 
-\`${message}\`
+${message}
 
 Check what's wrong by:
 - Using the [online contribution tool](${CONTRIBUTE_URL}?${urlQueryParams}).


### PR DESCRIPTION
Previously, errors were reported on a single line, where the inline code-fencing on message worked.

The current logic is:
The html fetcher throws FetchDocumentErrors, with the URL fenced with apostrophe `'`. Archivist collects these errors in InaccessibleContentError, which produces a multiline error message (generic text + foreach(\n- error)).

Because the message is multiline now, the inline code fencing with backticks no longer worked.

As a side effect, the GitHub URL identification included the closing \'\` in the URL. Without the \` the \' is not included in the URL href.

So dropping the now invalid backticks resolves both the invalid backticks and wrong URL linking.

Fixes #967