### PR TITLE
Trigger event on release to deploy documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,11 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+
+      - name: Trigger documentation deploy
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TRIGGER_DOCS_DEPLOY_TOKEN }}
+          event-type: engine-release
+          repository: OpenTermsArchive/docs
+          client-payload: '{"version": "${{ env.NEW_VERSION }}"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
 Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the names mandated by SemVer, within brackets: `[patch]`, `[minor]` or `[major]`. For example: `## Unreleased [minor]`.
 
-## Unreleased
+## Unreleased [minor]
+
+### Added
+
+- Trigger a release event on CI to deploy documentation website
 
 ## 0.23.0 - 2023-01-18
 ### Removed


### PR DESCRIPTION
Trigger an `engine-release` event to the `OpenTermsArchive/docs` repository. 

It will work with the merge of [this pull request](https://github.com/OpenTermsArchive/docs/pull/34) on the documentation website which listens on that event to deploy the documentation website.

To try this mecanism, use my forks to run the release event manually [here](https://github.com/clementbiron/OpenTermsArchive/actions/workflows/release.yml) and check that the action is triggered accordingly [here](https://github.com/clementbiron/ota-docs/actions/workflows/gh-pages.yml).