### PR TITLE
Empty PR to trigger release documentation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,18 @@ name: Release
 on:
   pull_request:
     branches: 
-      - main
-    types: [ closed ]
+      - test_trigger_jsdoc_workflow
+    types: [ opened, closed ]
 
 
 jobs:
-  changelog:
-    uses: "ambanum/OpenTermsArchive/.github/workflows/changelog.yml@main"
-  test:
-    uses: "ambanum/OpenTermsArchive/.github/workflows/test.yml@main"
+  # changelog:
+  #   uses: "ambanum/OpenTermsArchive/.github/workflows/changelog.yml@main"
+  # test:
+  #   uses: "ambanum/OpenTermsArchive/.github/workflows/test.yml@main"
   release:
-    if: github.event.pull_request.merged == true
-    needs: [ changelog, test ]
+    # if: github.event.pull_request.merged == true
+    # needs: [ changelog, test ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,58 +22,58 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: Configure Git author
-        run: |
-          git config --global user.name "Open Terms Archive Release Bot"
-          git config --global user.email "release-bot@opentermsarchive.org"
+      # - name: Configure Git author
+      #   run: |
+      #     git config --global user.name "Open Terms Archive Release Bot"
+      #     git config --global user.email "release-bot@opentermsarchive.org"
 
-      - name: Bump package version
-        run: |
-          echo "Release type obtained from the previous job: '${{ needs.changelog.outputs.release_type }}'"
-          echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ needs.changelog.outputs.release_type }})" >> $GITHUB_ENV
+      # - name: Bump package version
+      #   run: |
+      #     echo "Release type obtained from the previous job: '${{ needs.changelog.outputs.release_type }}'"
+      #     echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ needs.changelog.outputs.release_type }})" >> $GITHUB_ENV
 
-      - name: Update changelog unreleased section with new version
-        uses: superfaceai/release-changelog-action@v2
-        with:
-          version: ${{ env.NEW_VERSION }}
-          operation: release
+      # - name: Update changelog unreleased section with new version
+      #   uses: superfaceai/release-changelog-action@v2
+      #   with:
+      #     version: ${{ env.NEW_VERSION }}
+      #     operation: release
 
-      - name: Commit CHANGELOG.md and package.json changes and create tag
-        run: |
-          git add "package.json"
-          git add "package-lock.json"
-          git add "CHANGELOG.md"
-          git commit -m "Release ${{ env.NEW_VERSION }}"
-          git tag ${{ env.NEW_VERSION }}
+      # - name: Commit CHANGELOG.md and package.json changes and create tag
+      #   run: |
+      #     git add "package.json"
+      #     git add "package-lock.json"
+      #     git add "CHANGELOG.md"
+      #     git commit -m "Release ${{ env.NEW_VERSION }}"
+      #     git tag ${{ env.NEW_VERSION }}
 
-      - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks 
-        uses: CasperWA/push-protected@v2
-        with:
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-          branch: main
-          unprotect_reviews: true
+      # - name: Run status checks for release commit on temporary branch # Use temporary branch to enable pushing commits to this branch protected by required status checks 
+      #   uses: CasperWA/push-protected@v2
+      #   with:
+      #     token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+      #     branch: main
+      #     unprotect_reviews: true
 
-      - name: Push changes to repository
-        run: git push origin && git push --tags
+      # - name: Push changes to repository
+      #   run: git push origin && git push --tags
 
-      - name: Read version changelog
-        uses: superfaceai/release-changelog-action@v2
-        id: get-changelog
-        with:
-          version: ${{ env.NEW_VERSION }}
-          operation: read
+      # - name: Read version changelog
+      #   uses: superfaceai/release-changelog-action@v2
+      #   id: get-changelog
+      #   with:
+      #     version: ${{ env.NEW_VERSION }}
+      #     operation: read
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.NEW_VERSION }}
-          body: ${{ steps.get-changelog.outputs.changelog }}
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+      # - name: Create GitHub release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     tag_name: ${{ env.NEW_VERSION }}
+      #     body: ${{ steps.get-changelog.outputs.changelog }}
+      #     token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: Publish to NPM public repository
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+      # - name: Publish to NPM public repository
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     token: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 
       - name: Trigger documentation deploy
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  push:
   pull_request:
     branches: 
       - test_trigger_jsdoc_workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format is based on [Common Changelog](https://common-changelog.org).\
 Unlike Common Changelog, the `unreleased` section of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) is preserved with the addition of a tag to specify which type of release should be published and to foster discussions about it inside pull requests. This tag should be one of the names mandated by SemVer, within brackets: `[patch]`, `[minor]` or `[major]`. For example: `## Unreleased [minor]`.
 
-## Unreleased
+## Unreleased [minor]
+
+### Added
+
+- Test to trigger the release documentation workflow
 
 ## 0.24.0 - 2023-01-25
 ### Added


### PR DESCRIPTION
I probably made a mistake with the documentation deployment TOKEN in the PR https://github.com/ambanum/OpenTermsArchive/pull/987

This PR will allow to test if it work with the TOKEN update.